### PR TITLE
[WIP] MoePCBクラスのテンプレートクラス化

### DIFF
--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -1,0 +1,91 @@
+name: Build Test
+
+# トリガー指定
+on:
+  # 手動実行用
+  workflow_dispatch:
+  # PR自動実行用
+  pull_request:
+    # PR作成時、PRにpushしたとき、closeされたPRをreopenしたときに実行
+    types: [opened, synchronize, reopened]
+    # PRに以下のファイルの変更が含まれている場合に実行
+    paths:
+      - '**.h'
+      - '**.cpp'
+      - '**.ino'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    # リポジトリの clone と checkout
+    - name: Checkout Repository
+      uses: actions/checkout@v3
+      with:
+        path: checkout-dir
+        ref: ${{ github.head_ref || github.ref }}
+
+    # arduino-cli のインストールと examples のビルド
+    - name: Install arduino-cli and Build examples
+      run: |
+        # install arduino-cli
+        TOOL_DIR=${{ github.workspace }}/tool
+        mkdir -p "${TOOL_DIR}"
+        curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR="${TOOL_DIR}" sh
+        PATH=$PATH:${TOOL_DIR}/
+        echo "$PATH"
+
+        echo "::group::refresh platform indexes"
+        arduino-cli core update-index
+        echo "::endgroup::"
+
+        echo "::group::add arduino core and libraries"
+        arduino-cli core install arduino:avr
+        echo "::endgroup::"
+        arduino-cli core list # for debug
+
+        echo "::group::allow lib install by --git-url"
+        arduino-cli config init
+        arduino-cli config set library.enable_unsafe_install true
+        echo "::endgroup::"
+
+        echo "::group::add arduino libraries"
+        arduino-cli lib install --git-url https://github.com/adafruit/Adafruit_NeoPixel.git
+        arduino-cli lib install --git-url https://github.com/martin2250/ADCTouch.git
+        arduino-cli lib install --git-url https://github.com/arduino-libraries/MIDIUSB
+        echo "::endgroup::"
+
+        echo "::group::add MoePCB libraries"
+        USER_DIR=$(arduino-cli config dump | awk '/^directories:/{f=1} f{if($1=="user:"){f=0;print $0}}' | sed -E 's/^ *user: *//')
+        echo "USER_DIR=${USER_DIR}"
+        mv checkout-dir "${USER_DIR}/libraries/MoePCB"
+        echo "::endgroup::"
+        arduino-cli lib list --all # for debug
+
+        # enable problem matcher
+        echo "::add-matcher::${USER_DIR}/libraries/MoePCB/.github/workflows/gcc_matcher.json"
+
+        # build MoePCB sample projects
+        (cd "${USER_DIR}/libraries/MoePCB" && git ls-files examples/*.ino) | \
+        while IFS= read -r FILE_PATH || [[ -n "${FILE_PATH}" ]]; do
+          LOG_PATH=logs/${FILE_PATH%.ino}.log
+          echo "::group::build ${FILE_PATH}"
+          mkdir -p "$(dirname "${LOG_PATH}")"
+          (arduino-cli compile -b arduino:avr:leonardo "${USER_DIR}/libraries/MoePCB/${FILE_PATH}" --verbose --log-level trace 2>&1 || true) | tee "${LOG_PATH}"
+          echo "::endgroup::"
+        done
+
+        # disable problem matcher
+        echo "::remove-matcher owner=gcc-problem-matcher::"
+
+        echo "::group::list all files"
+        find "${USER_DIR}/libraries/MoePCB" -type f
+        echo "::endgroup::"
+
+    # ビルド時の出力をアーカイブとして保存
+    - name: Archive build results
+      uses: actions/upload-artifact@v3
+      with:
+        name: build_result_run-${{ github.run_id }}
+        path: logs

--- a/.github/workflows/gcc_matcher.json
+++ b/.github/workflows/gcc_matcher.json
@@ -1,0 +1,17 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "gcc-problem-matcher",
+            "pattern": [
+                {
+                    "regexp": "^(.*?):(\\d+):(\\d*):?\\s+(?:fatal\\s+)?(warning|error):\\s+(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                }
+            ]
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -36,3 +36,89 @@ USB-MIDIを使用する際は
 回路図など [こちら](https://github.com/MizuhasiYukkie/MOE-PCB)
 
 萌基板の紹介ページは [こちら](http://yuki-factory.main.jp/moe-pcb.html)
+
+
+## 設計 (ライブラリ実装者向け説明)
+
+### 基本の設計戦略
+ライブラリ利用者が以下のようなコードを書けることを目指しています。
+```
+MoePCB_Core<基板設定, モジュール1, モジュール2, ...> pcb;
+pcb.get_XXX_module().set_YYY(ZZZ);
+```
+
+MoePCB_Core は萌基板全体制御クラスです。<br>
+このクラスはテンプレートクラスになっていて、以下で説明する基板設定クラスとモジュールクラスを与えることで、
+利用者にとって最適な萌基板クラスとして利用できるようになります。
+
+基板設定には、FraduinoやCirduinoなどそれぞれの基板ごとに固有の設定値をまとめたクラスを与えます。<br>
+(基板設定クラスはライブラリで提供する)
+
+モジュールには、LEDやタッチセンサなど、萌基板に実装されている周辺回路の制御を行うクラスを与えます。<br>
+一部のモジュールクラスはそれ自身もテンプレートクラスとなっており、
+サブモジュールを与えてより詳細な機能を制御可能なものもあります。
+
+### モジュール
+現時点で実装済みのモジュールは以下の通りです。
+
+* LED: メインLED (フルカラーLED)
+* SubLED: サブLED (背面単色LED)
+* TouchSensor: タッチセンサ
+* Thermometer: 温度センサ (マイコン内蔵温度センサ)
+
+TODO: 今後実装していくモジュール
+* 環境センサ (Hinaduino, Tensuinoで利用)
+* 赤外線 (Patchoulino, Mariduino, Yukarinoで利用)
+
+### 命名規則案
+
+統一しないと後々大変になるので、思い付きで一通り決めました。<br>
+TODO: まだ全体に反映できていない + Arduino界隈のお作法を知らないため、規則を修正したうえでコードを直すかもです。
+
+* クラス・テンプレートパラメータ => upper camel case + snake case
+* 型 => lower camel case
+* private/protected メンバ変数 => lower snake case
+* public メンバ変数 => upper snake case
+* static メンバ関数 => upper camel case
+* private/protected メンバ関数 => lower camel case
+* public メンバ関数 => upper camel case
+* 関数引数/local変数 => lower camel case
+
+以下サンプルコード
+```
+template<typename T_TemplateTypeName_SubName>
+class MoePCB_ClassName_SubName {
+  friend class MoePCB_FriendClassName;
+
+private:
+  typedef int16_t private_new_type_name_t;
+  static constexpr int16_t private_static_constexpr_variable;
+
+public:
+  typedef int16_t public_new_type_name_t;
+  static constexpr int16_t Public_Static_Constexpr_Variable;
+
+public:
+  static void PublicStaticMethod(int16_t methodArgument) { }
+
+public:
+  MoePCB_ClassName_SubName() = default;
+  MoePCB_ClassName_SubName(const MoePCB_ClassName_SubName&) = delete;
+  MoePCB_ClassName_SubName(MoePCB_ClassName_SubName&&) = delete;
+  MoePCB_ClassName_SubName& operator= (const MoePCB_ClassName_SubName&) = delete;
+  MoePCB_ClassName_SubName& operator= (MoePCB_ClassName_SubName&&) = delete;
+  ~MoePCB_ClassName_SubName() = default;
+
+private:
+  void privateMethod(int16_t methodArgument) const { }
+
+public:
+  void PublicMethod(int16_t methodArgument) const { }
+
+public:
+  int16_t Public_Member;
+
+private:
+  int16_t private_member;
+};
+```

--- a/examples/KNMK-0001A_Fraduino_Basic_New/KNMK-0001A_Fraduino_Basic_New.ino
+++ b/examples/KNMK-0001A_Fraduino_Basic_New/KNMK-0001A_Fraduino_Basic_New.ino
@@ -1,5 +1,5 @@
 /*!
- * KNMK-0002A Cirduino向けソースコード
+ * KNMK-0001A Fraduino向けソースコード
  *
  * Copyright (c) 2023 Mizuhasi Yukkie, Onozawa Hiro
  * This software is released under the MIT license.
@@ -23,45 +23,45 @@
 // 萌基板モジュール新規実装を利用する
 #define USE_NEW_MOE_PCB
 #include <MoePCB.h>
-#include <Params/Cirno.h>
+#include <Params/Fran.h>
 
 volatile uint8_t PATTERN_MODE = 0;   // 点灯パターン 0-2
 volatile uint8_t BRIGHTNESS_IDX = 1; // 輝度レベル 0-3
 
-// 萌基板インスタンス (チルノ)
+// 萌基板インスタンス (フラン)
 // タッチセンサ、サブLED、メインLEDモジュールを利用
-// メインLEDモジュールには調光フィルタに FullSet (全部乗せ) 、色生成モジュールに Breath, Icy, Gaming の3種を利用
+// メインLEDモジュールには調光フィルタに FullSet (全部乗せ) 、色生成モジュールに Breath, Rainbow, Gaming の3種を利用
 MoePCB_Core<
-  MoePCB_Params_Cirno,
+  MoePCB_Params_Fran,
   MoePCB_TouchSensorModule,
   MoePCB_SubLEDModule,
   MoePCB_LED_Module<
     MoePCB_LEDColorFilter_FullSet,
     MoePCB_LEDColorCalculator_Breath,
-    MoePCB_LEDColorCalculator_Icy,
+    MoePCB_LEDColorCalculator_Rainbow,
     MoePCB_LEDColorCalculator_Gaming
   >
-> Cirno;
+> Fran;
 
 // 表面のLEDの並び
-constexpr MoePCB_Params_Cirno::LED::led_index_t led_idx_list[] = {
-  MoePCB_Params_Cirno::LED::Placement::LowerLeft,
-  MoePCB_Params_Cirno::LED::Placement::Left,
-  MoePCB_Params_Cirno::LED::Placement::UpperLeft,
-  MoePCB_Params_Cirno::LED::Placement::UpperRight,
-  MoePCB_Params_Cirno::LED::Placement::Right,
-  MoePCB_Params_Cirno::LED::Placement::LowerRight
+constexpr MoePCB_Params_Fran::LED::led_index_t led_idx_list[] = {
+  MoePCB_Params_Fran::LED::Placement::OuterLeft,
+  MoePCB_Params_Fran::LED::Placement::Left,
+  MoePCB_Params_Fran::LED::Placement::InnerLeft,
+  MoePCB_Params_Fran::LED::Placement::InnerRight,
+  MoePCB_Params_Fran::LED::Placement::Right,
+  MoePCB_Params_Fran::LED::Placement::OuterRight
 };
 
-// LEDモジュールの色生成処理を icy に設定
-void set_led_icy(MoePCB_LEDColorCalculator_Icy::Mode::type_t mode) {
-  auto& led = Cirno.getMainLED().getColorCalculator();
+// LEDモジュールの色生成処理を Rainbow に設定
+void set_led_rainbow(MoePCB_LEDColorCalculator_Rainbow::Mode::type_t mode) {
+  auto& led = Fran.getMainLED().getColorCalculator();
 
-  // Heart が breath なら 他はすべて icy
-  if (led.get_interface_breath(MoePCB_Params_Cirno::LED::Placement::Heart) != nullptr) {
+  // Heart が breath なら 他はすべて rainbow
+  if (led.get_interface_breath(MoePCB_Params_Fran::LED::Placement::Heart) != nullptr) {
     // 輝度レベルとモードを変更
-    for (MoePCB_Params_Cirno::LED::led_index_t led_idx = 0; led_idx < MoePCB_Params_Cirno::LED::Length; ++led_idx) {
-      auto const pI = led.get_interface_icy(led_idx);
+    for (MoePCB_Params_Fran::LED::led_index_t led_idx = 0; led_idx < MoePCB_Params_Fran::LED::Length; ++led_idx) {
+      auto const pI = led.get_interface_rainbow(led_idx);
       if (pI != nullptr) {
         pI->set_mode(mode);
         pI->set_brightness_level(BRIGHTNESS_IDX);
@@ -69,23 +69,24 @@ void set_led_icy(MoePCB_LEDColorCalculator_Icy::Mode::type_t mode) {
     }
   } else {
     // 色生成処理を breath, icy に変更
-    led.set_mode_breath(MoePCB_Params_Cirno::LED::Placement::Heart);
+    led.set_mode_breath(MoePCB_Params_Fran::LED::Placement::Heart);
 
-    for (MoePCB_Params_Cirno::LED::led_index_t led_idx = 0; led_idx < MoePCB_Params_Cirno::LED::Length; ++led_idx) {
-      if (led_idx == MoePCB_Params_Cirno::LED::Placement::Heart) { continue; }
-      led.set_mode_icy(led_idx, mode, BRIGHTNESS_IDX);
+    // レインボーモード,点灯パターンA（自動でキラキラ）（位相差60度）
+    for (uint8_t i = 0; i < sizeof(led_idx_list)/sizeof(led_idx_list[0]); ++i) {
+      const auto led_idx = led_idx_list[i];
+      led.set_mode_rainbow(led_idx, -60.0f * i, 1.2f, mode, BRIGHTNESS_IDX);
     }
   }
 }
 
 // LEDモジュールの色生成処理を gaming に設定
 void set_led_gaming() {
-  auto& led = Cirno.getMainLED().getColorCalculator();
+  auto& led = Fran.getMainLED().getColorCalculator();
 
   // Heart が gaming なら 他もすべて gaming
-  if (led.get_interface_gaming(MoePCB_Params_Cirno::LED::Placement::Heart) != nullptr) {
+  if (led.get_interface_gaming(MoePCB_Params_Fran::LED::Placement::Heart) != nullptr) {
     // 輝度レベルのみ変更
-    for (MoePCB_Params_Cirno::LED::led_index_t led_idx = 0; led_idx < MoePCB_Params_Cirno::LED::Length; ++led_idx) {
+    for (MoePCB_Params_Fran::LED::led_index_t led_idx = 0; led_idx < MoePCB_Params_Fran::LED::Length; ++led_idx) {
       auto const pI = led.get_interface_gaming(led_idx);
       if (pI != nullptr) {
         pI->set_brightness_level(BRIGHTNESS_IDX);
@@ -94,7 +95,7 @@ void set_led_gaming() {
   } else {
     // 色生成処理を gaming に変更（位相差約20度）
     // 元実装では step = 6 だが update 間隔が早まったため 5 に落とす (それでもやや早い)
-    led.set_mode_gaming(MoePCB_Params_Cirno::LED::Placement::Heart, 0, 5, BRIGHTNESS_IDX);
+    led.set_mode_gaming(MoePCB_Params_Fran::LED::Placement::Heart, 0, 5, BRIGHTNESS_IDX);
 
     for (uint8_t i = 0; i < sizeof(led_idx_list)/sizeof(led_idx_list[0]); ++i) {
       const auto led_idx = led_idx_list[i];
@@ -108,46 +109,47 @@ void set_led_gaming() {
 void apply() {
   // LEDモジュールの色生成処理を点灯モードに応じ切り替え
   switch(PATTERN_MODE) {
-  case 0: set_led_icy(MoePCB_LEDColorCalculator_Icy::Mode::Natural); break;
-  case 1: set_led_icy(MoePCB_LEDColorCalculator_Icy::Mode::Digital); break;
+  case 0: set_led_rainbow(MoePCB_LEDColorCalculator_Rainbow::Mode::NaturalAndTwinkle); break;
+  case 1: set_led_rainbow(MoePCB_LEDColorCalculator_Rainbow::Mode::DigitalAndTwinkle); break;
   case 2: set_led_gaming(); break;
   }
 
   // LEDモジュールの色生成処理のベース輝度は最大値で固定
-  Cirno.getMainLED().getColorCalculator().setBrightnessAll(255);
+  Fran.getMainLED().getColorCalculator().setBrightnessAll(255);
 
   // フィルタの直前の色情報を初期化
-  Cirno.getMainLED().getColorFilter().resetLastColor();
+  Fran.getMainLED().getColorFilter().resetLastColor();
 
   // LEDモジュールの色生成処理、フィルタ処理の更新を有効化
-  Cirno.getMainLED().getColorCalculator().setEnabledAll(true);
-  Cirno.getMainLED().getColorFilter().setEnabled(true);
+  Fran.getMainLED().getColorCalculator().setEnabledAll(true);
+  Fran.getMainLED().getColorFilter().setEnabled(true);
+
 }
 
 // 了解コール
 void acknowledge(int ms) {
   // サブLED点灯
-  Cirno.getSubLED().set(true);
-  Cirno.getSubLED().show();
+  Fran.getSubLED().set(true);
+  Fran.getSubLED().show();
 
   // LEDモジュールの色生成処理、フィルタ処理の更新を止める
-  Cirno.getMainLED().getColorCalculator().setEnabledAll(false);
-  Cirno.getMainLED().getColorFilter().setEnabled(false);
+  Fran.getMainLED().getColorCalculator().setEnabledAll(false);
+  Fran.getMainLED().getColorFilter().setEnabled(false);
 
   // すべてのLEDを消灯
-  Cirno.getMainLED().getRawLED().clear();
-  Cirno.getMainLED().getRawLED().show();
+  Fran.getMainLED().getRawLED().clear();
+  Fran.getMainLED().getRawLED().show();
 
   // 少し待機 (割り込みがかかってもLEDモジュールを無効化しているため消灯したままになる)
   delay(ms);
 
   // LEDモジュールの色生成処理、フィルタ処理の更新を再開
-  Cirno.getMainLED().getColorCalculator().setEnabledAll(true);
-  Cirno.getMainLED().getColorFilter().setEnabled(true);
+  Fran.getMainLED().getColorCalculator().setEnabledAll(true);
+  Fran.getMainLED().getColorFilter().setEnabled(true);
 
   // サブLED消灯
-  Cirno.getSubLED().set(false);
-  Cirno.getSubLED().show();
+  Fran.getSubLED().set(false);
+  Fran.getSubLED().show();
 }
 
 
@@ -155,7 +157,7 @@ void acknowledge(int ms) {
 // タイマー割り込みにより一定間隔で実行される処理
 // 割り込み間隔は要確認
 void MoePCB_Task() {
-  Cirno.interrupt(); // 萌基板割り込み実行
+  Fran.interrupt(); // 萌基板割り込み実行
 }
 
 // 起動後に1回呼ばれるArduinoの関数
@@ -163,10 +165,10 @@ void setup() {
 //  Serial.begin(9600);//シリアル通信を使いたいとき
 
   // 萌基板初期化
-  Cirno.begin();
+  Fran.begin();
 
   // LED ベース光量 最大値に設定
-  Cirno.getMainLED().getRawLED().setBrightness(255);
+  Fran.getMainLED().getRawLED().setBrightness(255);
 
   apply();
 }
@@ -174,32 +176,32 @@ void setup() {
 // setup後繰り返し呼ばれるArduinoの関数
 void loop() {
   // 萌基板フレーム更新処理
-  Cirno.update();
+  Fran.update();
 
 // TODO: ThermometerModule を利用したサンプルを書く
 /* CPU内蔵温度感知機能を使う場合は校正した方がいいです（個体差大）
     static uint8_t cnt;
     if(30<cnt){
       cnt=0;
-      Serial.print(Cirno.cputemp_raw()); Serial.print(" / ");//CPU温度ADC値を見たい時
-      Serial.print(Cirno.cputemp(26.0, 305.0));//305.0のところは各自の校正値を入れる：校正時の周辺の実測温度、その時のCPU温度ADC値（上段）    
+      Serial.print(Fran.cputemp_raw()); Serial.print(" / ");//CPU温度ADC値を見たい時
+      Serial.print(Fran.cputemp(26.0, 305.0));//305.0のところは各自の校正値を入れる：校正時の周辺の実測温度、その時のCPU温度ADC値（上段）    
       Serial.println(" C");
     }
     cnt++;
     //50度超えると暑いよ〜
-    if(50 < Cirno.cputemp(26.0, 305.0) )Cirno.heat(true);//cputempに校正値を与えると気温が返ってくる
-    else Cirno.heat(false);
+    if(50 < Fran.cputemp(26.0, 305.0) )Fran.heat(true);//cputempに校正値を与えると気温が返ってくる
+    else Fran.heat(false);
 
     //10度下回ると寒いよ〜
-    if(Cirno.cputemp(26.0, 305.0) < 10 )Cirno.cold(true);//cputempに校正値を与えると気温が返ってくる
-    else Cirno.cold(false);
+    if(Fran.cputemp(26.0, 305.0) < 10 )Fran.cold(true);//cputempに校正値を与えると気温が返ってくる
+    else Fran.cold(false);
 */    
 
   // タッチセンサインスタンスへの参照
-  auto& touch_module = Cirno.getTouchSensor();
-  auto& hair_sensor = touch_module.getRawTouchSensor(MoePCB_Params_Cirno::TouchSensor::Placement::Hair);
-  auto& chest_sensor = touch_module.getRawTouchSensor(MoePCB_Params_Cirno::TouchSensor::Placement::Chest);
-  auto& skirt_sensor = touch_module.getRawTouchSensor(MoePCB_Params_Cirno::TouchSensor::Placement::Skirt);
+  auto& touch_module = Fran.getTouchSensor();
+  auto& hair_sensor = touch_module.getRawTouchSensor(MoePCB_Params_Fran::TouchSensor::Placement::Hair);
+  auto& chest_sensor = touch_module.getRawTouchSensor(MoePCB_Params_Fran::TouchSensor::Placement::Chest);
+  auto& skirt_sensor = touch_module.getRawTouchSensor(MoePCB_Params_Fran::TouchSensor::Placement::Skirt);
 
   // 髪タッチ検知
   if (hair_sensor.isOnTouch()) {
@@ -212,7 +214,7 @@ void loop() {
 
   // 胸タッチ検出
   // 長押しと判定した場合怒りモードを有効にする
-  Cirno.getMainLED().getColorFilter().set_state_angry(chest_sensor.isPressing());
+  Fran.getMainLED().getColorFilter().set_state_angry(chest_sensor.isPressing());
 
   //スカートタッチ検出
   if (skirt_sensor.isOnTouch()) {

--- a/examples/KNMK-0002A_Cirduino_Basic_New/KNMK-0002A_Cirduino_Basic_New.ino
+++ b/examples/KNMK-0002A_Cirduino_Basic_New/KNMK-0002A_Cirduino_Basic_New.ino
@@ -1,0 +1,218 @@
+/*!
+ * KNMK-0002A Cirduino向けソースコード
+ *
+ * Copyright (c) 2023 Mizuhasi Yukkie
+ * This software is released under the MIT license.
+ * see https://opensource.org/licenses/MIT
+*/
+
+/*
+ * This program requires the folloing libraries.
+ * このコードを使用するためには、下記のライブラリをインストールしてください。
+ * 
+ * 【ADCTouch】 https://github.com/martin2250/ADCTouch
+ * 【Adafruit_NeoPixel】 https://github.com/adafruit/Adafruit_NeoPixel
+ * 【MoePCB】 https://github.com/MizuhasiYukkie/MoePCB
+ * 
+ * ツール→ボード："Arduino Leonardo"を選択
+ * ツール→シリアルポート：「USBで接続済みの萌基板のポート」（ArduinoLeonardoと表示されます）を選択
+ * 「マイコンボードに書き込む」を実行するとここに書いてあるプログラムが書き込まれます。
+ * ※USB端子経由で書き込めない場合はICSP端子からAVRISP mkⅡなどを用いて書き込んでください。
+ */
+
+// 萌基板モジュール新規実装を利用する
+#define USE_NEW_MOE_PCB
+#include <MoePCB.h>
+#include <Params/Cirno.h>
+
+volatile uint8_t PATTERN_MODE = 0;   // 点灯パターン 0-2
+volatile uint8_t BRIGHTNESS_IDX = 1; // 輝度レベル 0-3
+
+// 萌基板インスタンス (チルノ)
+// タッチセンサ、サブLED、メインLEDモジュールを利用
+// メインLEDモジュールには調光フィルタに FullSet (全部乗せ) 、色生成モジュールに Breath, Icy, Gaming の3種を利用
+MoePCB_Core<
+  MoePCB_Params_Cirno,
+  MoePCB_TouchSensorModule,
+  MoePCB_SubLEDModule,
+  MoePCB_LED_Module<
+    MoePCB_LEDColorFilter_FullSet,
+    MoePCB_LEDColorCalculator_Breath,
+    MoePCB_LEDColorCalculator_Icy,
+    MoePCB_LEDColorCalculator_Gaming
+  >
+> Cirno;
+
+// LEDモジュールの色生成処理を icy に設定
+void set_led_icy(MoePCB_LEDColorCalculator_Icy::Mode::type_t mode) {
+  auto& led = Cirno.getMainLED().getColorCalculator();
+
+  // Heart が breath なら 他はすべて icy
+  if (led.get_interface_breath(MoePCB_Params_Cirno::LED::Placement::Heart) != nullptr) {
+    // 輝度レベルとモードを変更
+    for (MoePCB_Params_Cirno::LED::led_index_t led_idx = 0; led_idx < MoePCB_Params_Cirno::LED::Length; ++led_idx) {
+      auto const pI = led.get_interface_icy(led_idx);
+      if (pI != nullptr) {
+        pI->set_mode(mode);
+        pI->set_brightness_level(BRIGHTNESS_IDX);
+      }
+    }
+  } else {
+    // 色生成処理を breath, icy に変更
+    led.set_mode_breath(MoePCB_Params_Cirno::LED::Placement::Heart);
+
+    for (MoePCB_Params_Cirno::LED::led_index_t led_idx = 0; led_idx < MoePCB_Params_Cirno::LED::Length; ++led_idx) {
+      if (led_idx == MoePCB_Params_Cirno::LED::Placement::Heart) { continue; }
+      led.set_mode_icy(led_idx,  mode, BRIGHTNESS_IDX);
+    }
+  }
+}
+
+// LEDモジュールの色生成処理を gaming に設定
+void set_led_gaming() {
+  auto& led = Cirno.getMainLED().getColorCalculator();
+
+  // Heart が gaming なら 他もすべて gaming
+  if (led.get_interface_gaming(MoePCB_Params_Cirno::LED::Placement::Heart) != nullptr) {
+    // 輝度レベルのみ変更
+    for (MoePCB_Params_Cirno::LED::led_index_t led_idx = 0; led_idx < MoePCB_Params_Cirno::LED::Length; ++led_idx) {
+      auto const pI = led.get_interface_gaming(led_idx);
+      if (pI != nullptr) {
+        pI->set_brightness_level(BRIGHTNESS_IDX);
+      }
+    }
+  } else {
+    // 色生成処理を gaming に変更（位相差約20度）
+    // 元実装では step = 6 だが update 間隔が早まったため 5 に落とす (それでもやや早い)
+    led.set_mode_gaming(MoePCB_Params_Cirno::LED::Placement::Heart,      256*0/(360/20), 5, BRIGHTNESS_IDX);
+    led.set_mode_gaming(MoePCB_Params_Cirno::LED::Placement::UpperLeft,  256*0/(360/20), 5, BRIGHTNESS_IDX);
+    led.set_mode_gaming(MoePCB_Params_Cirno::LED::Placement::Left,       256*1/(360/20), 5, BRIGHTNESS_IDX);
+    led.set_mode_gaming(MoePCB_Params_Cirno::LED::Placement::LowerLeft,  256*2/(360/20), 5, BRIGHTNESS_IDX);
+    led.set_mode_gaming(MoePCB_Params_Cirno::LED::Placement::LowerRight, 256*3/(360/20), 5, BRIGHTNESS_IDX);
+    led.set_mode_gaming(MoePCB_Params_Cirno::LED::Placement::Right,      256*4/(360/20), 5, BRIGHTNESS_IDX);
+    led.set_mode_gaming(MoePCB_Params_Cirno::LED::Placement::UpperRight, 256*5/(360/20), 5, BRIGHTNESS_IDX);
+  }
+}
+
+// LED調光モード反映
+void apply() {
+  // LEDモジュールの色生成処理を点灯モードに応じ切り替え
+  switch(PATTERN_MODE) {
+  case 0: set_led_icy(MoePCB_LEDColorCalculator_Icy::Mode::Natural); break;
+  case 1: set_led_icy(MoePCB_LEDColorCalculator_Icy::Mode::Digital); break;
+  case 2: set_led_gaming(); break;
+  }
+
+  // LEDモジュールの色生成処理のベース輝度は最大値で固定
+  Cirno.getMainLED().getColorCalculator().setBrightnessAll(255);
+
+  // LEDモジュールの色生成処理、フィルタ処理の更新を有効化
+  Cirno.getMainLED().getColorCalculator().setEnabledAll(true);
+  Cirno.getMainLED().getColorFilter().setEnabled(true);
+}
+
+// 了解コール
+void acknowledge(int ms) {
+  // サブLED点灯
+  Cirno.getSubLED().set(true);
+  Cirno.getSubLED().show();
+
+  // LEDモジュールの色生成処理、フィルタ処理の更新を止める
+  Cirno.getMainLED().getColorCalculator().setEnabledAll(false);
+  Cirno.getMainLED().getColorFilter().setEnabled(false);
+
+  // すべてのLEDを消灯
+  Cirno.getMainLED().getRawLED().clear();
+  Cirno.getMainLED().getRawLED().show();
+
+  // 少し待機 (割り込みがかかってもLEDモジュールを無効化しているため消灯したままになる)
+  delay(ms);
+
+  // LEDモジュールの色生成処理、フィルタ処理の更新を再開
+  Cirno.getMainLED().getColorCalculator().setEnabledAll(true);
+  Cirno.getMainLED().getColorFilter().setEnabled(true);
+
+  // サブLED消灯
+  Cirno.getSubLED().set(false);
+  Cirno.getSubLED().show();
+}
+
+
+
+// タイマー割り込みにより一定間隔で実行される処理
+// 割り込み間隔は要確認
+void MoePCB_Task() {
+  Cirno.interrupt(); // 萌基板割り込み実行
+}
+
+// 起動後に1回呼ばれるArduinoの関数
+void setup() {
+//  Serial.begin(9600);//シリアル通信を使いたいとき
+
+  // 萌基板初期化
+  Cirno.begin();
+
+  // LED ベース光量 最大値に設定
+  Cirno.getMainLED().getRawLED().setBrightness(255);
+
+  apply();
+}
+
+// setup後繰り返し呼ばれるArduinoの関数
+void loop() {
+  // 萌基板フレーム更新処理
+  Cirno.update();
+
+// TODO: ThermometerModule を利用したサンプルを書く
+/* CPU内蔵温度感知機能を使う場合は校正した方がいいです（個体差大）
+    static uint8_t cnt;
+    if(30<cnt){
+      cnt=0;
+      Serial.print(Cirno.cputemp_raw()); Serial.print(" / ");//CPU温度ADC値を見たい時
+      Serial.print(Cirno.cputemp(26.0, 305.0));//305.0のところは各自の校正値を入れる：校正時の周辺の実測温度、その時のCPU温度ADC値（上段）    
+      Serial.println(" C");
+    }
+    cnt++;
+    //50度超えると暑いよ〜
+    if(50 < Cirno.cputemp(26.0, 305.0) )Cirno.heat(true);//cputempに校正値を与えると気温が返ってくる
+    else Cirno.heat(false);
+
+    //10度下回ると寒いよ〜
+    if(Cirno.cputemp(26.0, 305.0) < 10 )Cirno.cold(true);//cputempに校正値を与えると気温が返ってくる
+    else Cirno.cold(false);
+*/    
+
+  // タッチセンサインスタンスへの参照
+  auto& touch_module = Cirno.getTouchSensor();
+  auto& hair_sensor = touch_module.getRawTouchSensor(MoePCB_Params_Cirno::TouchSensor::Placement::Hair);
+  auto& chest_sensor = touch_module.getRawTouchSensor(MoePCB_Params_Cirno::TouchSensor::Placement::Chest);
+  auto& skirt_sensor = touch_module.getRawTouchSensor(MoePCB_Params_Cirno::TouchSensor::Placement::Skirt);
+
+  // 髪タッチ検知
+  if (hair_sensor.isOnTouch()) {
+    // 輝度レベルインクリメント
+    BRIGHTNESS_IDX = (BRIGHTNESS_IDX + 1) % 4;
+
+    acknowledge(80); 
+    apply();
+  }
+
+  // 胸タッチ検出
+  // 長押しと判定した場合怒りモードを有効にする
+  Cirno.getMainLED().getColorFilter().set_state_angry(chest_sensor.getPressingCount() > 50);
+
+  //スカートタッチ検出
+  if (skirt_sensor.isOnTouch()) {
+    if (PATTERN_MODE == 0)     PATTERN_MODE = 1;
+    else if(PATTERN_MODE == 1) PATTERN_MODE = 2;
+    else                       PATTERN_MODE = 0;
+
+    acknowledge(80); 
+    apply();
+  }
+  
+  // 60FPSを目指したdelay呼び出し。loop関数内の処理でdelay呼び出しが含まれているものもあり、
+  // またタイマ割り込みの処理を行っている間loop関数の処理は進行しないため、実際にはloop関数は
+  // 目標より低いFPSで進行する。また処理内容ごとに処理時間が変わるため、FPSは一定にならない。
+  delay(15);
+}

--- a/examples/KNMK-0003A_Hinaduino_Basic_New/KNMK-0003A_Hinaduino_Basic_New.ino
+++ b/examples/KNMK-0003A_Hinaduino_Basic_New/KNMK-0003A_Hinaduino_Basic_New.ino
@@ -1,0 +1,269 @@
+/*!
+ * KNMK-0003A Hinaduino向けソースコード
+ *
+ * Copyright (c) 2023 Mizuhasi Yukkie, Onozawa Hiro
+ * This software is released under the MIT license.
+ * see https://opensource.org/licenses/MIT
+*/
+
+/*
+ * This program requires the folloing libraries.
+ * このコードを使用するためには、下記のライブラリをインストールしてください。
+ * 
+ * 【ADCTouch】 https://github.com/martin2250/ADCTouch
+ * 【Adafruit_NeoPixel】 https://github.com/adafruit/Adafruit_NeoPixel
+ * 【MoePCB】 https://github.com/MizuhasiYukkie/MoePCB
+ * 
+ * ツール→ボード："Arduino Leonardo"を選択
+ * ツール→シリアルポート：「USBで接続済みの萌基板のポート」（ArduinoLeonardoと表示されます）を選択
+ * 「マイコンボードに書き込む」を実行するとここに書いてあるプログラムが書き込まれます。
+ * ※USB端子経由で書き込めない場合はICSP端子からAVRISP mkⅡなどを用いて書き込んでください。
+ */
+
+// 萌基板モジュール新規実装を利用する
+#define USE_NEW_MOE_PCB
+#include <MoePCB.h>
+#include <Params/Hina.h>
+
+volatile uint8_t PATTERN_MODE = 0;   // 点灯パターン 0-2
+volatile uint8_t PATTERN_SUBMODE = 0;   // 点灯サブパターン 0-1
+volatile uint8_t BRIGHTNESS_IDX = 1; // 輝度レベル 0-3
+
+// 萌基板インスタンス (チルノ)
+// タッチセンサ、サブLED、メインLEDモジュールを利用
+// メインLEDモジュールには調光フィルタに FullSet (全部乗せ) 、色生成モジュールに Breath, Autumn, Rainbow, Gaming の4種を利用
+MoePCB_Core<
+  MoePCB_Params_Hina,
+  MoePCB_TouchSensorModule,
+  MoePCB_SubLEDModule,
+  MoePCB_LED_Module<
+    MoePCB_LEDColorFilter_FullSet,
+    MoePCB_LEDColorCalculator_Breath,
+    MoePCB_LEDColorCalculator_Autumn,
+    MoePCB_LEDColorCalculator_Rainbow,
+    MoePCB_LEDColorCalculator_Gaming
+  >
+> Hina;
+
+// 表面のLEDの並び
+constexpr MoePCB_Params_Hina::LED::led_index_t led_idx_list[] = {
+  MoePCB_Params_Hina::LED::Placement::Head,
+  MoePCB_Params_Hina::LED::Placement::UpperRight,
+  MoePCB_Params_Hina::LED::Placement::Right,
+  MoePCB_Params_Hina::LED::Placement::LowerRight,
+  MoePCB_Params_Hina::LED::Placement::InnerRight,
+  MoePCB_Params_Hina::LED::Placement::InnerLeft,
+  MoePCB_Params_Hina::LED::Placement::LowerLeft,
+  MoePCB_Params_Hina::LED::Placement::Left,
+  MoePCB_Params_Hina::LED::Placement::UpperLeft
+};
+
+// LEDモジュールの色生成処理を Autumn に設定
+void set_led_autumn(int base, bool onlyChangeBrightness) {
+  auto& led = Hina.getMainLED().getColorCalculator();
+
+  // UpperLeft が autumn なら Heart は breath, 他はすべて autumn
+  if (onlyChangeBrightness && led.get_interface_autumn(MoePCB_Params_Hina::LED::Placement::UpperLeft) != nullptr) {
+    // 輝度レベルとモードを変更
+    for (MoePCB_Params_Hina::LED::led_index_t led_idx = 0; led_idx < MoePCB_Params_Hina::LED::Length; ++led_idx) {
+      auto const pI = led.get_interface_autumn(led_idx);
+      if (pI != nullptr) {
+        pI->set_brightness_level(BRIGHTNESS_IDX);
+      }
+    }
+  } else {
+    // 色生成処理を breath, autumn に変更
+    led.set_mode_breath(MoePCB_Params_Hina::LED::Placement::Heart);
+
+    for (uint8_t i = 0; i < sizeof(led_idx_list)/sizeof(led_idx_list[0]); ++i) {
+      const auto led_idx = led_idx_list[i];
+      led.set_mode_autumn(led_idx, -base * i, 0.9375f, BRIGHTNESS_IDX);
+    }
+  }
+}
+
+// LEDモジュールの色生成処理を rainbow に設定
+void set_led_rainbow(float base) {
+  auto& led = Hina.getMainLED().getColorCalculator();
+
+  // UpperLeft が rainbow なら Heart は breath, 他はすべて rainbow
+  if (led.get_interface_rainbow(MoePCB_Params_Hina::LED::Placement::UpperLeft) != nullptr) {
+    // 輝度レベルのみ変更
+    for (MoePCB_Params_Hina::LED::led_index_t led_idx = 0; led_idx < MoePCB_Params_Hina::LED::Length; ++led_idx) {
+      auto const pI = led.get_interface_rainbow(led_idx);
+      if (pI != nullptr) {
+        pI->set_brightness_level(BRIGHTNESS_IDX);
+      }
+    }
+  } else {
+    // 色生成処理を breath, rainbow に変更
+    led.set_mode_breath(MoePCB_Params_Hina::LED::Placement::Heart);
+
+    constexpr auto mode = MoePCB_LEDColorCalculator_Rainbow::Mode::NaturalAndTwinkle;
+    for (uint8_t i = 0; i < sizeof(led_idx_list)/sizeof(led_idx_list[0]); ++i) {
+      const auto led_idx = led_idx_list[i];
+      led.set_mode_rainbow(led_idx, -base * i, 1.2f, mode, BRIGHTNESS_IDX);
+    }
+  }
+}
+
+// LEDモジュールの色生成処理を gaming に設定
+void set_led_gaming() {
+  auto& led = Hina.getMainLED().getColorCalculator();
+
+  // Heart が gaming なら 他もすべて gaming
+  if (led.get_interface_gaming(MoePCB_Params_Hina::LED::Placement::Heart) != nullptr) {
+    // 輝度レベルのみ変更
+    for (MoePCB_Params_Hina::LED::led_index_t led_idx = 0; led_idx < MoePCB_Params_Hina::LED::Length; ++led_idx) {
+      auto const pI = led.get_interface_gaming(led_idx);
+      if (pI != nullptr) {
+        pI->set_brightness_level(BRIGHTNESS_IDX);
+      }
+    }
+  } else {
+    // 色生成処理を gaming に変更（位相差約20度）
+    // 元実装では step = 6 だが update 間隔が早まったため 5 に落とす (それでもやや早い)
+    led.set_mode_gaming(MoePCB_Params_Hina::LED::Placement::Heart, 0, 5, BRIGHTNESS_IDX);
+
+    for (uint8_t i = 0; i < sizeof(led_idx_list)/sizeof(led_idx_list[0]); ++i) {
+      const auto led_idx = led_idx_list[i];
+      const uint8_t shift = ((uint16_t)256*i)/(360/20);
+      led.set_mode_gaming(led_idx, -shift, 5, BRIGHTNESS_IDX);
+    }
+  }
+}
+
+// LED調光モード反映
+void apply(bool onlyChangeBrightness) {
+  // LEDモジュールの色生成処理を点灯モードに応じ切り替え
+  switch(PATTERN_MODE) {
+  case 0: set_led_autumn((PATTERN_SUBMODE == 0) ? 20 : 200, onlyChangeBrightness); break;
+  case 1: set_led_rainbow((PATTERN_SUBMODE == 0) ? 30.0f : 300.0f); break;
+  case 2: set_led_gaming(); break;
+  }
+
+  // LEDモジュールの色生成処理のベース輝度は最大値で固定
+  Hina.getMainLED().getColorCalculator().setBrightnessAll(255);
+
+  // フィルタの直前の色情報を初期化
+  Hina.getMainLED().getColorFilter().resetLastColor();
+
+  // LEDモジュールの色生成処理、フィルタ処理の更新を有効化
+  Hina.getMainLED().getColorCalculator().setEnabledAll(true);
+  Hina.getMainLED().getColorFilter().setEnabled(true);
+}
+
+// 了解コール
+void acknowledge(int ms) {
+  // サブLED点灯
+  Hina.getSubLED().set(true);
+  Hina.getSubLED().show();
+
+  // LEDモジュールの色生成処理、フィルタ処理の更新を止める
+  Hina.getMainLED().getColorCalculator().setEnabledAll(false);
+  Hina.getMainLED().getColorFilter().setEnabled(false);
+
+  // すべてのLEDを消灯
+  Hina.getMainLED().getRawLED().clear();
+  Hina.getMainLED().getRawLED().show();
+
+  // 少し待機 (割り込みがかかってもLEDモジュールを無効化しているため消灯したままになる)
+  delay(ms);
+
+  // LEDモジュールの色生成処理、フィルタ処理の更新を再開
+  Hina.getMainLED().getColorCalculator().setEnabledAll(true);
+  Hina.getMainLED().getColorFilter().setEnabled(true);
+
+  // サブLED消灯
+  Hina.getSubLED().set(false);
+  Hina.getSubLED().show();
+}
+
+
+
+// タイマー割り込みにより一定間隔で実行される処理
+// 割り込み間隔は要確認
+void MoePCB_Task() {
+  Hina.interrupt(); // 萌基板割り込み実行
+}
+
+// 起動後に1回呼ばれるArduinoの関数
+void setup() {
+//  Serial.begin(9600);//シリアル通信を使いたいとき
+
+  // 萌基板初期化
+  Hina.begin();
+
+  // LED ベース光量 最大値に設定
+  Hina.getMainLED().getRawLED().setBrightness(255);
+
+  apply(false);
+}
+
+// setup後繰り返し呼ばれるArduinoの関数
+void loop() {
+  // 萌基板フレーム更新処理
+  Hina.update();
+
+// TODO: ThermometerModule を利用したサンプルを書く
+/* CPU内蔵温度感知機能を使う場合は校正した方がいいです（個体差大）
+    static uint8_t cnt;
+    if(30<cnt){
+      cnt=0;
+      Serial.print(Hina.cputemp_raw()); Serial.print(" / ");//CPU温度ADC値を見たい時
+      Serial.print(Hina.cputemp(26.0, 305.0));//305.0のところは各自の校正値を入れる：校正時の周辺の実測温度、その時のCPU温度ADC値（上段）    
+      Serial.println(" C");
+    }
+    cnt++;
+    //50度超えると暑いよ〜
+    if(50 < Hina.cputemp(26.0, 305.0) )Hina.heat(true);//cputempに校正値を与えると気温が返ってくる
+    else Hina.heat(false);
+
+    //10度下回ると寒いよ〜
+    if(Hina.cputemp(26.0, 305.0) < 10 )Hina.cold(true);//cputempに校正値を与えると気温が返ってくる
+    else Hina.cold(false);
+*/    
+
+  // タッチセンサインスタンスへの参照
+  auto& touch_module = Hina.getTouchSensor();
+  auto& ribbon_sensor = touch_module.getRawTouchSensor(MoePCB_Params_Hina::TouchSensor::Placement::Ribbon);
+  auto& hair_sensor = touch_module.getRawTouchSensor(MoePCB_Params_Hina::TouchSensor::Placement::Hair);
+  auto& chest_sensor = touch_module.getRawTouchSensor(MoePCB_Params_Hina::TouchSensor::Placement::Chest);
+  auto& skirt_sensor = touch_module.getRawTouchSensor(MoePCB_Params_Hina::TouchSensor::Placement::Skirt);
+
+  // 髪タッチ検知
+  if (hair_sensor.isOnTouch()) {
+    // 輝度レベルインクリメント
+    BRIGHTNESS_IDX = (BRIGHTNESS_IDX + 1) % 4;
+
+    acknowledge(80); 
+    apply(true);
+  }
+
+  // 胸タッチ検出
+  // 長押しと判定した場合怒りモードを有効にする
+  Hina.getMainLED().getColorFilter().set_state_angry(chest_sensor.isPressing());
+
+  //スカートタッチ検出
+  if (skirt_sensor.isOnTouch()) {
+    PATTERN_SUBMODE=0;   //サブモードを戻しておく
+
+    PATTERN_MODE = (PATTERN_MODE + 1) % 3;
+
+    acknowledge(80); 
+    apply(false);
+  }
+  
+  // リボンタッチ検出
+  if (PATTERN_MODE != 2 && ribbon_sensor.isOnTouch()) {
+    PATTERN_SUBMODE = (PATTERN_SUBMODE + 1) % 2;
+
+    acknowledge(80); 
+    apply(false);
+  }
+
+  // 60FPSを目指したdelay呼び出し。loop関数内の処理でdelay呼び出しが含まれているものもあり、
+  // またタイマ割り込みの処理を行っている間loop関数の処理は進行しないため、実際にはloop関数は
+  // 目標より低いFPSで進行する。また処理内容ごとに処理時間が変わるため、FPSは一定にならない。
+  delay(15);
+}

--- a/examples/KNMK-0004A_Tensuino_Basic_New/KNMK-0004A_Tensuino_Basic_New.ino
+++ b/examples/KNMK-0004A_Tensuino_Basic_New/KNMK-0004A_Tensuino_Basic_New.ino
@@ -1,0 +1,282 @@
+/*!
+ * KNMK-0004A Tensuino向けソースコード
+ *
+ * Copyright (c) 2023 Mizuhasi Yukkie, Onozawa Hiro
+ * This software is released under the MIT license.
+ * see https://opensource.org/licenses/MIT
+*/
+
+/*
+ * This program requires the folloing libraries.
+ * このコードを使用するためには、下記のライブラリをインストールしてください。
+ * 
+ * 【ADCTouch】 https://github.com/martin2250/ADCTouch
+ * 【Adafruit_NeoPixel】 https://github.com/adafruit/Adafruit_NeoPixel
+ * 【MoePCB】 https://github.com/MizuhasiYukkie/MoePCB
+ * 
+ * ツール→ボード："Arduino Leonardo"を選択
+ * ツール→シリアルポート：「USBで接続済みの萌基板のポート」（ArduinoLeonardoと表示されます）を選択
+ * 「マイコンボードに書き込む」を実行するとここに書いてあるプログラムが書き込まれます。
+ * ※USB端子経由で書き込めない場合はICSP端子からAVRISP mkⅡなどを用いて書き込んでください。
+ */
+
+// 萌基板モジュール新規実装を利用する
+#define USE_NEW_MOE_PCB
+#include <MoePCB.h>
+#include <Params/Tenshi.h>
+
+volatile uint8_t PATTERN_MODE = 0;   // 点灯パターン 0-2
+volatile uint8_t PATTERN_SUBMODE = 0;   // 点灯サブパターン 0-1
+volatile uint8_t BRIGHTNESS_IDX = 1; // 輝度レベル 0-3
+
+// 萌基板インスタンス (チルノ)
+// タッチセンサ、サブLED、メインLEDモジュールを利用
+// メインLEDモジュールには調光フィルタに FullSet (全部乗せ) 、色生成モジュールに Breath, Rainbow, Swprd, Gaming の4種を利用
+MoePCB_Core<
+  MoePCB_Params_Tenshi,
+  MoePCB_TouchSensorModule,
+  MoePCB_SubLEDModule,
+  MoePCB_LED_Module<
+    MoePCB_LEDColorFilter_FullSet,
+    MoePCB_LEDColorCalculator_Breath,
+    MoePCB_LEDColorCalculator_Rainbow,
+    MoePCB_LEDColorCalculator_Sword,
+    MoePCB_LEDColorCalculator_Gaming
+  >
+> Tenshi;
+
+// スカート部分のLEDの並び
+#if 0
+// 元実装の並び
+constexpr MoePCB_Params_Tenshi::LED::led_index_t led_idx_list[] = {
+  MoePCB_Params_Tenshi::LED::Placement::Center,
+  MoePCB_Params_Tenshi::LED::Placement::Left,
+  MoePCB_Params_Tenshi::LED::Placement::OuterLeft,
+  MoePCB_Params_Tenshi::LED::Placement::Right,
+  MoePCB_Params_Tenshi::LED::Placement::OuterRight
+};
+#else
+// 自然な並び
+constexpr MoePCB_Params_Tenshi::LED::led_index_t led_idx_list[] = {
+  MoePCB_Params_Tenshi::LED::Placement::OuterLeft,
+  MoePCB_Params_Tenshi::LED::Placement::Left,
+  MoePCB_Params_Tenshi::LED::Placement::Center,
+  MoePCB_Params_Tenshi::LED::Placement::Right,
+  MoePCB_Params_Tenshi::LED::Placement::OuterRight
+};
+#endif
+
+// LEDモジュールの色生成処理を rainbow と sword に設定
+void set_led_rainbow_and_sword(MoePCB_LEDColorCalculator_Rainbow::Mode::type_t modeRainbow, MoePCB_LEDColorCalculator_Sword::Mode::type_t modeSword, MoePCB_LEDColorCalculator_Sword::Color::type_t colorSword) {
+  auto& led = Tenshi.getMainLED().getColorCalculator();
+
+  // Heart が breath なら 他はすべて rainbow と sword
+  if (led.get_interface_breath(MoePCB_Params_Tenshi::LED::Placement::Heart) != nullptr) {
+    // 輝度レベルとモードを変更
+    // スカート: rainbow
+    for (uint8_t i = 0; i < sizeof(led_idx_list)/sizeof(led_idx_list[0]); ++i) {
+      const auto led_idx = led_idx_list[i];
+      auto const pI = led.get_interface_rainbow(led_idx);
+      if (pI != nullptr) {
+        pI->set_mode(modeRainbow);
+        pI->set_brightness_level(BRIGHTNESS_IDX);
+      }
+    }
+    // 剣
+    for (MoePCB_Params_Tenshi::LED::led_index_t i = 0; i < MoePCB_Params_Tenshi::LED::Placement::SwordLEDNum; ++i) {
+      const auto led_idx = MoePCB_Params_Tenshi::LED::Placement::SwordBottom + i;
+      auto const pI = led.get_interface_sword(led_idx);
+      if (pI != nullptr) {
+        pI->set_mode(modeSword);
+        pI->set_color(colorSword);
+        pI->set_brightness_level(BRIGHTNESS_IDX);
+      }
+    }
+  } else {
+    // 色生成処理を breath, rainbow, sword に変更
+    led.set_mode_breath(MoePCB_Params_Tenshi::LED::Placement::Heart);
+
+    // スカート: rainbow
+    for (uint8_t i = 0; i < sizeof(led_idx_list)/sizeof(led_idx_list[0]); ++i) {
+      const auto led_idx = led_idx_list[i];
+      led.set_mode_rainbow(led_idx, -60*i, 1.2f, modeRainbow, BRIGHTNESS_IDX);
+    }
+    // 剣
+    for (MoePCB_Params_Tenshi::LED::led_index_t i = 0; i < MoePCB_Params_Tenshi::LED::Placement::SwordLEDNum; ++i) {
+      const auto led_idx = MoePCB_Params_Tenshi::LED::Placement::SwordBottom + i;
+      led.set_mode_sword(led_idx, -28*i, colorSword, modeSword, BRIGHTNESS_IDX);
+    }
+  }
+}
+
+// LEDモジュールの色生成処理を gaming に設定
+void set_led_gaming() {
+  auto& led = Tenshi.getMainLED().getColorCalculator();
+
+  // Heart が gaming なら 他もすべて gaming
+  if (led.get_interface_gaming(MoePCB_Params_Tenshi::LED::Placement::Heart) != nullptr) {
+    // 輝度レベルのみ変更
+    for (MoePCB_Params_Tenshi::LED::led_index_t led_idx = 0; led_idx < MoePCB_Params_Tenshi::LED::Length; ++led_idx) {
+      auto const pI = led.get_interface_gaming(led_idx);
+      if (pI != nullptr) {
+        pI->set_brightness_level(BRIGHTNESS_IDX);
+      }
+    }
+  } else {
+    // 色生成処理を gaming に変更（位相差約10度）
+    // 元実装では step = 6 だが update 間隔が早まったため 5 に落とす (それでもやや早い)
+    led.set_mode_gaming(MoePCB_Params_Tenshi::LED::Placement::Heart, 0, 5, BRIGHTNESS_IDX);
+
+    // スカート: rainbow
+    for (uint8_t i = 0; i < sizeof(led_idx_list)/sizeof(led_idx_list[0]); ++i) {
+      const auto led_idx = led_idx_list[i];
+      const uint8_t shift = ((uint16_t)256*i)/(360/10);
+      led.set_mode_gaming(led_idx, -shift, 5, BRIGHTNESS_IDX);
+    }
+    // 剣
+    for (MoePCB_Params_Tenshi::LED::led_index_t i = 0; i < MoePCB_Params_Tenshi::LED::Placement::SwordLEDNum; ++i) {
+      const auto led_idx = MoePCB_Params_Tenshi::LED::Placement::SwordBottom + i;
+      const uint8_t shift = ((uint16_t)256*i)/(360/10);
+      led.set_mode_gaming(led_idx, -shift, 5, BRIGHTNESS_IDX);
+    }
+  }
+}
+
+// LED調光モード反映
+void apply() {
+  // LEDモジュールの色生成処理を点灯モードに応じ切り替え
+  switch(PATTERN_MODE) {
+  case 0: set_led_rainbow_and_sword(MoePCB_LEDColorCalculator_Rainbow::Mode::NaturalAndTwinkle, MoePCB_LEDColorCalculator_Sword::Mode::Default, (PATTERN_SUBMODE==0)?MoePCB_LEDColorCalculator_Sword::Color::FireRed : MoePCB_LEDColorCalculator_Sword::Color::SkyBlue); break;
+  case 1: set_led_rainbow_and_sword(MoePCB_LEDColorCalculator_Rainbow::Mode::DigitalAndTwinkle, MoePCB_LEDColorCalculator_Sword::Mode::Twinkle, (PATTERN_SUBMODE==0)?MoePCB_LEDColorCalculator_Sword::Color::SkyBlue : MoePCB_LEDColorCalculator_Sword::Color::FireRed); break;
+  case 2: set_led_gaming(); break;
+  }
+
+  // LEDモジュールの色生成処理のベース輝度は最大値で固定
+  Tenshi.getMainLED().getColorCalculator().setBrightnessAll(255);
+
+  // フィルタの直前の色情報を初期化
+  Tenshi.getMainLED().getColorFilter().resetLastColor();
+
+  // LEDモジュールの色生成処理、フィルタ処理の更新を有効化
+  Tenshi.getMainLED().getColorCalculator().setEnabledAll(true);
+  Tenshi.getMainLED().getColorFilter().setEnabled(true);
+}
+
+// 了解コール
+void acknowledge(int ms) {
+  // サブLED点灯
+  Tenshi.getSubLED().set(true);
+  Tenshi.getSubLED().show();
+
+  // LEDモジュールの色生成処理、フィルタ処理の更新を止める
+  Tenshi.getMainLED().getColorCalculator().setEnabledAll(false);
+  Tenshi.getMainLED().getColorFilter().setEnabled(false);
+
+  // すべてのLEDを消灯
+  Tenshi.getMainLED().getRawLED().clear();
+  Tenshi.getMainLED().getRawLED().show();
+
+  // 少し待機 (割り込みがかかってもLEDモジュールを無効化しているため消灯したままになる)
+  delay(ms);
+
+  // LEDモジュールの色生成処理、フィルタ処理の更新を再開
+  Tenshi.getMainLED().getColorCalculator().setEnabledAll(true);
+  Tenshi.getMainLED().getColorFilter().setEnabled(true);
+
+  // サブLED消灯
+  Tenshi.getSubLED().set(false);
+  Tenshi.getSubLED().show();
+}
+
+
+
+// タイマー割り込みにより一定間隔で実行される処理
+// 割り込み間隔は要確認
+void MoePCB_Task() {
+  Tenshi.interrupt(); // 萌基板割り込み実行
+}
+
+// 起動後に1回呼ばれるArduinoの関数
+void setup() {
+//  Serial.begin(9600);//シリアル通信を使いたいとき
+
+  // 萌基板初期化
+  Tenshi.begin();
+
+  // LED ベース光量 最大値に設定
+  Tenshi.getMainLED().getRawLED().setBrightness(255);
+
+  apply();
+}
+
+// setup後繰り返し呼ばれるArduinoの関数
+void loop() {
+  // 萌基板フレーム更新処理
+  Tenshi.update();
+
+// TODO: ThermometerModule を利用したサンプルを書く
+/* CPU内蔵温度感知機能を使う場合は校正した方がいいです（個体差大）
+    static uint8_t cnt;
+    if(30<cnt){
+      cnt=0;
+      Serial.print(Tenshi.cputemp_raw()); Serial.print(" / ");//CPU温度ADC値を見たい時
+      Serial.print(Tenshi.cputemp(26.0, 305.0));//305.0のところは各自の校正値を入れる：校正時の周辺の実測温度、その時のCPU温度ADC値（上段）    
+      Serial.println(" C");
+    }
+    cnt++;
+    //50度超えると暑いよ〜
+    if(50 < Tenshi.cputemp(26.0, 305.0) )Tenshi.heat(true);//cputempに校正値を与えると気温が返ってくる
+    else Tenshi.heat(false);
+
+    //10度下回ると寒いよ〜
+    if(Tenshi.cputemp(26.0, 305.0) < 10 )Tenshi.cold(true);//cputempに校正値を与えると気温が返ってくる
+    else Tenshi.cold(false);
+*/    
+
+  // タッチセンサインスタンスへの参照
+  auto& touch_module = Tenshi.getTouchSensor();
+  auto& hair_sensor = touch_module.getRawTouchSensor(MoePCB_Params_Tenshi::TouchSensor::Placement::Hair);
+  auto& chest_sensor = touch_module.getRawTouchSensor(MoePCB_Params_Tenshi::TouchSensor::Placement::Chest);
+  auto& skirt_sensor = touch_module.getRawTouchSensor(MoePCB_Params_Tenshi::TouchSensor::Placement::Skirt);
+  auto& sword_sensor = touch_module.getRawTouchSensor(MoePCB_Params_Tenshi::TouchSensor::Placement::Sword);
+
+  // 髪タッチ検知
+  if (hair_sensor.isOnTouch()) {
+    // 輝度レベルインクリメント
+    BRIGHTNESS_IDX = (BRIGHTNESS_IDX + 1) % 4;
+
+    acknowledge(80); 
+    apply();
+  }
+
+  // 胸タッチ検出
+  // 長押しと判定した場合怒りモードを有効にする
+  Tenshi.getMainLED().getColorFilter().set_state_angry(chest_sensor.isPressing());
+
+  // スカートタッチ検出
+  if (skirt_sensor.isOnTouch()) {
+    PATTERN_SUBMODE = 0;
+    if (PATTERN_MODE == 0)     PATTERN_MODE = 1;
+    else if(PATTERN_MODE == 1) PATTERN_MODE = 2;
+    else                       PATTERN_MODE = 0;
+
+    acknowledge(80); 
+    apply();
+  }
+  
+  // 剣タッチ検出
+  // サブモード切替
+  if (sword_sensor.isOnTouch()) {
+    if (PATTERN_MODE != 2) {
+      PATTERN_SUBMODE = (PATTERN_SUBMODE + 1) % 2;
+
+      acknowledge(80); 
+      apply();
+    }
+  }
+
+  // 60FPSを目指したdelay呼び出し。loop関数内の処理でdelay呼び出しが含まれているものもあり、
+  // またタイマ割り込みの処理を行っている間loop関数の処理は進行しないため、実際にはloop関数は
+  // 目標より低いFPSで進行する。また処理内容ごとに処理時間が変わるため、FPSは一定にならない。
+  delay(15);
+}

--- a/src/Modules/LED/ColorCalculator/Autumn.h
+++ b/src/Modules/LED/ColorCalculator/Autumn.h
@@ -1,0 +1,203 @@
+/*!
+ * Modules/LED/ColorCalculator/Autumn.h - Library for Moe-PCB (Moe Kiban)
+ *
+ * Copyright (c) 2022-2023 Mizuhasi Yukkie, Onozawa Hiro
+ * Released under the MIT license.
+ * see https://opensource.org/licenses/MIT
+ */
+
+#ifndef Modules_LED_ColorCalculator_Autumn_h
+#define Modules_LED_ColorCalculator_Autumn_h
+
+#include "Base.h"
+#include <new>
+
+// 暖色でゲーミング + たまにキラキラ
+class MoePCB_LEDColorCalculator_Autumn
+{
+private:
+  // クラスを識別するための固有の定数
+  // TODO: 適当な関数の配置先アドレス等コンパイル時に一意に定まる値を流用したい (コンパイラの警告に引っかかるため出来ていない)
+  static constexpr uintptr_t IdValue = 0x10;
+
+public:
+  // 明るさレベル
+  class BrightnessLevel {
+    friend class MoePCB_LEDColorCalculator_Autumn;
+
+  public:
+    typedef uint8_t type_t;
+
+  private:
+    static constexpr type_t RequireBits = 2; // 内部用 : 必要なビット幅
+  };
+
+public:
+  // LED調光モジュール個別インターフェース
+  class SpecificInterface : public MoePCB_LEDColorCalculator_SpecificInterfaceBase
+  {
+  private:
+    // 連続して同じLEDをピカピカしないよう、インターバルを設定
+    typedef uint8_t twinkle_interval_t;
+    static constexpr twinkle_interval_t twinkle_cooltime = 120;
+
+    //明るさレベルに応じた輝度
+#if __cpp_constexpr >= 201304
+    // C++14以降向け (こちらの実装でもビルド、実行できるが警告が出る)
+    // cite: https://cpprefjp.github.io/lang/cpp14/relaxing_constraints_on_constexpr.html
+    static inline constexpr uint8_t BrightnessTable[4] = { 10, 25,  65, 175 }; // 通常輝度
+    static inline constexpr uint8_t TwinkleTable[4]    = { 40, 65, 155, 255 }; // ランダムきらきら輝度
+    constexpr uint8_t GetBrightness(BrightnessLevel::type_t brightness_level) { return BrightnessTable[brightness_level]; }
+    constexpr uint8_t GetTwinkleBrightness(BrightnessLevel::type_t brightness_level) { return TwinkleTable[brightness_level]; }
+#else
+    constexpr uint8_t GetBrightness(BrightnessLevel::type_t brightness_level) {
+      // 基本光量
+      switch (brightness_level) {
+        case 0: return 10;
+        case 1: return 25;
+        case 2: return 65;
+        case 3: return 175;
+        default: return 0;
+      }
+    }
+    constexpr uint8_t GetTwinkleBrightness(BrightnessLevel::type_t brightness_level) {
+      // ランダムきらきら輝度
+      switch (brightness_level) {
+        case 0: return 40;
+        case 1: return 65;
+        case 2: return 155;
+        case 3: return 255;
+        default: return 0;
+      }
+    }
+#endif
+
+  public:
+    SpecificInterface() = delete;
+    SpecificInterface(int phase_shift, float step, BrightnessLevel::type_t brightness_level)
+      : brightness_level(brightness_level)
+      , twinkle_interval(random(0, twinkle_cooltime))
+      , autumn_cnt(phase_shift)
+      , step(step)
+    { }
+    ~SpecificInterface() = default;
+
+  protected:
+    void* identifier() const override { return (void *) IdValue; }
+    void begin() override { }
+    void end() override { }
+
+    color_t update() override
+    {
+      // V 輝度
+      uint8_t V;
+      bool forceV = false;
+      {
+        V = GetBrightness(brightness_level); // 基本光量
+
+        // 連続して同じLEDをピカピカしないように考慮
+        if (twinkle_interval > 0) {
+          --twinkle_interval;
+        }
+        else {
+          if(random(0, 250) == 0){ //ランダムで明るくする
+            V = GetTwinkleBrightness(brightness_level); //キラッと光量
+          }
+        }
+
+        // 輝度反映
+        V = (V * this->brightness) / 256;
+      }
+
+      // H 色相
+      uint16_t H;
+      {
+        // [-30, 30) の autumn_cnt を [0, 30] で折り返す値 hue に変換
+        float hue;
+        if (autumn_cnt < 0) {
+          hue = -autumn_cnt;
+        } else {
+          hue = autumn_cnt;
+        }
+
+        // autumn_cnt 更新
+        autumn_cnt += step;
+        if (autumn_cnt >= 30.0f) {
+          autumn_cnt -= 60.0f;
+        }
+        if (autumn_cnt < -30.0f) {
+          autumn_cnt += 60.0f;
+        }
+
+        // 色相計算
+        H = (uint16_t) (hue * (float)(65535.0 / 360.0));
+      }
+
+      // S 彩度
+      uint8_t S;
+      {
+        S = 255; // 彩度MAX
+      }
+
+      return color_t(H, S, V, false, false, forceV);
+    }
+
+  public:
+    // 明るさレベル最大値を取得
+    static constexpr BrightnessLevel::type_t get_max_brightness_level() {
+#if __cpp_constexpr >= 201304
+      return sizeof(BrightnessTable)/sizeof(BrightnessTable[0]) - 1;
+#else
+      return 4 - 1;
+#endif
+    }
+    // 明るさレベルを取得
+    BrightnessLevel::type_t get_brightness_level(void) const { return brightness_level; }
+    // 明るさレベルを設定
+    void set_brightness_level(BrightnessLevel::type_t level) {
+      if (level <= get_max_brightness_level()) {
+        brightness_level = level;
+      }
+    }
+
+    // フレーム当たりの色相変化量を取得
+    float get_step() const { return step; }
+    // フレーム当たりの色相変化量を設定
+    void set_step(float v) { step = v; }
+
+  private:
+    // 初期化で与える値
+    BrightnessLevel::type_t brightness_level : BrightnessLevel::RequireBits; // 明るさレベル
+
+    // 自動で更新する値
+    twinkle_interval_t twinkle_interval;
+    float autumn_cnt; // カウンタ　[-30, 30)
+    float step; // 1フレームで色相環を回す角度
+  };
+
+  // LED調光モジュールクラス用インターフェース
+  template<class T_MoePCB_Params>
+  class ModuleInterface : public MoePCB_LEDColorCalculator_ModuleInterfaceBase<T_MoePCB_Params>
+  {
+  public:
+    // 調光モードを Autumn に設定する
+    void set_mode_autumn(typename T_MoePCB_Params::LED::led_index_t led_idx, int phase_shift, float step = 0.5f, BrightnessLevel::type_t brightness_level = 1) {
+      void * const p = this->allocateInterface(led_idx);
+      new(p) SpecificInterface(phase_shift, step, brightness_level);
+    }
+
+    // 調光モード Autumn の調光モジュールインターフェースを取得する
+    // 調光モードが Autumn 以外の場合は nullptr が返る
+    SpecificInterface* get_interface_autumn(typename T_MoePCB_Params::LED::led_index_t led_idx) {
+      auto const pBase = this->getInterface(led_idx);
+      if (pBase == nullptr) { return nullptr; }
+      if (pBase->identifier() == (void *) IdValue) {
+        return reinterpret_cast<SpecificInterface *>(pBase);
+      } else {
+        return nullptr;
+      }
+    }
+  };
+};
+
+#endif

--- a/src/Modules/LED/ColorCalculator/Autumn.h
+++ b/src/Modules/LED/ColorCalculator/Autumn.h
@@ -39,7 +39,7 @@ public:
   private:
     // 連続して同じLEDをピカピカしないよう、インターバルを設定
     typedef uint8_t twinkle_interval_t;
-    static constexpr twinkle_interval_t twinkle_cooltime = 120;
+    static constexpr twinkle_interval_t twinkle_cooltime = 32;
 
     //明るさレベルに応じた輝度
 #if __cpp_constexpr >= 201304
@@ -102,6 +102,7 @@ public:
         else {
           if(random(0, 250) == 0){ //ランダムで明るくする
             V = GetTwinkleBrightness(brightness_level); //キラッと光量
+            forceV = true;
           }
         }
 
@@ -112,7 +113,7 @@ public:
       // H 色相
       uint16_t H;
       {
-        // [-30, 30) の autumn_cnt を [0, 30] で折り返す値 hue に変換
+        // [-120, 120) の autumn_cnt を [120, 240] で折り返す値 hue に変換
         float hue;
         if (autumn_cnt < 0) {
           hue = -autumn_cnt;
@@ -122,11 +123,11 @@ public:
 
         // autumn_cnt 更新
         autumn_cnt += step;
-        if (autumn_cnt >= 30.0f) {
-          autumn_cnt -= 60.0f;
+        if (autumn_cnt >= 120.0f) {
+          autumn_cnt -= 240.0f;
         }
-        if (autumn_cnt < -30.0f) {
-          autumn_cnt += 60.0f;
+        if (autumn_cnt < -120.0f) {
+          autumn_cnt += 240.0f;
         }
 
         // 色相計算
@@ -181,7 +182,7 @@ public:
   {
   public:
     // 調光モードを Autumn に設定する
-    void set_mode_autumn(typename T_MoePCB_Params::LED::led_index_t led_idx, int phase_shift, float step = 0.5f, BrightnessLevel::type_t brightness_level = 1) {
+    void set_mode_autumn(typename T_MoePCB_Params::LED::led_index_t led_idx, int phase_shift, float step = 1.0f, BrightnessLevel::type_t brightness_level = 1) {
       void * const p = this->allocateInterface(led_idx);
       new(p) SpecificInterface(phase_shift, step, brightness_level);
     }

--- a/src/Modules/LED/ColorCalculator/Base.h
+++ b/src/Modules/LED/ColorCalculator/Base.h
@@ -1,0 +1,113 @@
+/*!
+ * Modules/LED/ColorCalculator/Base.h - Library for Moe-PCB (Moe Kiban)
+ *
+ * Copyright (c) 2022-2023 Mizuhasi Yukkie, Onozawa Hiro
+ * Released under the MIT license.
+ * see https://opensource.org/licenses/MIT
+ */
+
+#ifndef Modules_LED_ColorCalculator_Base_h
+#define Modules_LED_ColorCalculator_Base_h
+
+// LED調光モジュール個別インターフェースの基底
+// 毎フレーム色情報を計算する
+class MoePCB_LEDColorCalculator_SpecificInterfaceBase
+{
+  template<template<class U_LEDParams, class U_LEDColorCalculator> class T_LEDColorFilter, class... T_LEDColorCalculators>
+  friend class MoePCB_LED_Module;
+
+public:
+  // 色情報 (HSV形式) のみをもつ
+  struct color_raw {
+  public:
+    typedef uint16_t hue_t;
+    typedef uint8_t sat_t;
+    typedef uint8_t val_t;
+
+  public:
+    color_raw()
+      : color_raw(0, 0, 0)
+    { }
+    color_raw(hue_t H, sat_t S, val_t V)
+      : H(H), S(S), V(V)
+    { }
+    ~color_raw() = default;
+    color_raw(const color_raw&) = default;
+    color_raw(color_raw&&) = default;
+    color_raw& operator=(const color_raw&) = default;
+    color_raw& operator=(color_raw&&) = default;
+
+  public:
+    hue_t H;
+    sat_t S;
+    val_t V;
+  };
+
+  // 色情報 (HSV形式) と調光情報をもつ
+  struct color : public color_raw {
+  public:
+    color()
+      : color(0, 0, 0)
+    { }
+    color(uint16_t H, uint8_t S, uint8_t V)
+      : color(H, S, V, false, false, false)
+    { }
+    color(const color_raw& raw)
+      : color_raw(raw), forceH(true), forceS(true), forceV(true)
+    { }
+    color(color_raw&& raw)
+      : color_raw(raw), forceH(true), forceS(true), forceV(true)
+    { }
+    color(hue_t H, sat_t S, val_t V, bool forceH, bool forceS, bool forceV)
+      : color_raw(H, S, V), forceH(forceH), forceS(forceS), forceV(forceV)
+    { }
+    ~color() = default;
+    color(const color&) = default;
+    color(color&&) = default;
+    color& operator=(const color&) = default;
+    color& operator=(color&&) = default;
+
+  public:
+    bool forceH : 1;
+    bool forceS : 1;
+    bool forceV : 1;
+  };
+
+public:
+  typedef color_raw color_raw_t;
+  typedef color color_t;
+
+public:
+  virtual ~MoePCB_LEDColorCalculator_SpecificInterfaceBase() = default;
+  virtual void* identifier() const = 0;
+
+protected:
+  virtual void begin() = 0;
+  virtual void end() = 0;
+  virtual color_t update() = 0;
+
+public:
+  void setBrightness(uint8_t brightness) { this->brightness = brightness; }
+  uint8_t get_brightness() const { return this->brightness; }
+
+protected:
+  uint8_t brightness;
+};
+
+// LED調光モジュールクラス用インターフェースの基底
+// LED調光モジュールクラスにはライブラリ内部向けに、
+// 調光モジュールのアロケート、アドレス取得処理を実装する
+template<class T_MoePCB_Params>
+class MoePCB_LEDColorCalculator_ModuleInterfaceBase
+{
+public:
+  typedef typename T_MoePCB_Params::LED::led_index_t led_index_t;
+
+protected:
+  // アロケートのみ行いアドレスを返す
+  virtual void* allocateInterface(led_index_t) = 0;
+  // アドレス取得のみ行う
+  virtual MoePCB_LEDColorCalculator_SpecificInterfaceBase* getInterface(led_index_t) = 0;
+};
+
+#endif

--- a/src/Modules/LED/ColorCalculator/Breath.h
+++ b/src/Modules/LED/ColorCalculator/Breath.h
@@ -1,0 +1,108 @@
+/*!
+ * Modules/LED/ColorCalculator/Breath.h - Library for Moe-PCB (Moe Kiban)
+ *
+ * Copyright (c) 2022-2023 Mizuhasi Yukkie, Onozawa Hiro
+ * Released under the MIT license.
+ * see https://opensource.org/licenses/MIT
+ */
+
+#ifndef Modules_LED_ColorCalculator_Breath_h
+#define Modules_LED_ColorCalculator_Breath_h
+
+#include "Base.h"
+#include <new>
+
+// ゆっくり呼吸するような白色点滅
+class MoePCB_LEDColorCalculator_Breath
+{
+private:
+  // クラスを識別するための固有の定数
+  // TODO: 適当な関数の配置先アドレス等コンパイル時に一意に定まる値を流用したい (コンパイラの警告に引っかかるため出来ていない)
+  static constexpr uintptr_t IdValue = 0x20;
+
+public:
+  // LED調光モジュール個別インターフェース
+  class SpecificInterface : public MoePCB_LEDColorCalculator_SpecificInterfaceBase
+  {
+  public:
+    SpecificInterface()
+      : breath_cnt(0)
+    { }
+    ~SpecificInterface() = default;
+
+  protected:
+    void* identifier() const override { return (void *) IdValue; }
+    void begin() override { }
+    void end() override { }
+
+    color_t update() override
+    {
+      // V 輝度
+      uint8_t V;
+      {
+        //イージングはなし
+        if (breath_cnt < 128) {
+          V = breath_cnt * 2;
+        }
+        else {
+          V = (255 - breath_cnt) * 2;
+        }
+
+        // 輝度反映
+        V = (V * this->brightness) / 256;
+      }
+
+      // H 色相
+      uint16_t H;
+      {
+        // 色環は関係なし
+        H = 0;
+      }
+
+      // S 彩度
+      uint8_t S;
+      {
+        //彩度ゼロ
+        S = 0;
+      }
+
+      // カウンタ
+      {
+        ++breath_cnt;
+      }
+
+      return color_t(H, S, V, false, false, true);
+    }
+
+  private:
+    // 自動で更新する値
+    uint8_t breath_cnt; // カウンタ
+  };
+
+  // LED調光モジュールクラス用インターフェース
+  template<class T_MoePCB_Params>
+  class ModuleInterface : public MoePCB_LEDColorCalculator_ModuleInterfaceBase<T_MoePCB_Params>
+  {
+  public:
+    // 調光モードを Breath に設定する
+    void set_mode_breath(typename T_MoePCB_Params::LED::led_index_t led_idx) {
+      void * const p = this->allocateInterface(led_idx);
+      new(p) SpecificInterface();
+    }
+
+    // 調光モード Breath の調光モジュールインターフェースを取得する
+    // 調光モードが Breath 以外の場合は nullptr が返る
+    SpecificInterface* get_interface_breath(typename T_MoePCB_Params::LED::led_index_t led_idx) {
+      auto const pBase = this->getInterface(led_idx);
+      if (pBase == nullptr) { return nullptr; }
+      auto const pI = reinterpret_cast<SpecificInterface *>(pBase);
+      if (pBase->identifier() == (void *) IdValue) {
+        return pI;
+      } else {
+        return nullptr;
+      }
+    }
+  };
+};
+
+#endif

--- a/src/Modules/LED/ColorCalculator/Gaming.h
+++ b/src/Modules/LED/ColorCalculator/Gaming.h
@@ -1,0 +1,165 @@
+/*!
+ * Modules/LED/ColorCalculator/Gaming.h - Library for Moe-PCB (Moe Kiban)
+ *
+ * Copyright (c) 2022-2023 Mizuhasi Yukkie, Onozawa Hiro
+ * Released under the MIT license.
+ * see https://opensource.org/licenses/MIT
+ */
+
+#ifndef Modules_LED_ColorCalculator_Gaming_h
+#define Modules_LED_ColorCalculator_Gaming_h
+
+#include "Base.h"
+#include <new>
+
+// ゲーミングモード
+class MoePCB_LEDColorCalculator_Gaming
+{
+private:
+  // クラスを識別するための固有の定数
+  // TODO: 適当な関数の配置先アドレス等コンパイル時に一意に定まる値を流用したい (コンパイラの警告に引っかかるため出来ていない)
+  static constexpr uintptr_t IdValue = 0x30;
+
+public:
+  // 明るさレベル
+  class BrightnessLevel {
+    friend class MoePCB_LEDColorCalculator_Gaming;
+
+  public:
+    typedef uint8_t type_t;
+
+  private:
+    static constexpr type_t RequireBits = 2; // 内部用 : 必要なビット幅
+  };
+
+public:
+  // LED調光モジュール個別インターフェース
+  class SpecificInterface : public MoePCB_LEDColorCalculator_SpecificInterfaceBase
+  {
+  private:
+    //明るさレベルに応じた輝度
+#if __cpp_constexpr >= 201304
+    // C++14以降向け (こちらの実装でもビルド、実行できるが警告が出る)
+    // cite: https://cpprefjp.github.io/lang/cpp14/relaxing_constraints_on_constexpr.html
+    static inline constexpr uint8_t BrightnessTable[4] = { 25, 65, 175, 250 }; // 通常輝度
+    constexpr uint8_t GetBrightness(BrightnessLevel::type_t brightness_level) { return BrightnessTable[brightness_level]; }
+#else
+    constexpr uint8_t GetBrightness(BrightnessLevel::type_t brightness_level) {
+      // 基本光量より１段明るい
+      switch (brightness_level) {
+        case 0: return 25;
+        case 1: return 65;
+        case 2: return 175;
+        case 3: return 250;
+        default: return 0;
+      }
+    }
+#endif
+
+  public:
+    SpecificInterface() = delete;
+    SpecificInterface(uint8_t phase_shift, uint8_t step, BrightnessLevel::type_t brightness_level)
+      : brightness_level(brightness_level)
+      , gaming_cnt(phase_shift)
+      , step(step)
+    { }
+    ~SpecificInterface() = default;
+
+  protected:
+    void* identifier() const override { return (void *) IdValue; }
+    void begin() override { }
+    void end() override { }
+
+    color_t update() override
+    {
+      // V 輝度
+      uint8_t V;
+      {
+        V = GetBrightness(brightness_level); // 基本光量より１段明るい
+
+        // 輝度反映
+        V = (V * this->brightness) / 256;
+      }
+
+      // H 色相
+      uint16_t H;
+      {
+        // [0, 256) -> [0, 65536) の範囲変換なので、256倍するだけでよい
+        H = (uint16_t)gaming_cnt * 256;
+      }
+
+      // S 彩度
+      uint8_t S;
+      {
+        // 最大値に固定
+        S = 255;
+      }
+
+      // ゲーミング用カウンタ 0-255で一周
+      {
+        // オーバーフローすることで勝手に次の周に進む
+        gaming_cnt += step;
+      }
+
+      return color_t(H, S, V);
+    }
+
+  public:
+    // 明るさレベル最大値を取得
+    static constexpr BrightnessLevel::type_t get_max_brightness_level() {
+#if __cpp_constexpr >= 201304
+      return sizeof(BrightnessTable)/sizeof(BrightnessTable[0]) - 1;
+#else
+      return 4 - 1;
+#endif
+    }
+    // 明るさレベルを取得
+    BrightnessLevel::type_t get_brightness_level(void) const { return brightness_level; }
+    // 明るさレベルを設定
+    void set_brightness_level(BrightnessLevel::type_t level) {
+      if (level <= get_max_brightness_level()) {
+        brightness_level = level;
+      }
+    }
+
+    // フレーム当たりの色相変化量を取得
+    uint8_t get_step() const { return step; }
+    // フレーム当たりの色相変化量を設定
+    void set_step(uint8_t v) { step = v; }
+
+  private:
+    // 初期化で与える値
+    BrightnessLevel::type_t brightness_level : BrightnessLevel::RequireBits; // 明るさレベル
+
+    // 自動で更新する値
+    uint8_t gaming_cnt; // カウンタ
+    uint8_t step; // 1フレームあたりのカウンタ増分
+  };
+
+  // LED調光モジュールクラス用インターフェース
+  template<class T_MoePCB_Params>
+  class ModuleInterface : public MoePCB_LEDColorCalculator_ModuleInterfaceBase<T_MoePCB_Params>
+  {
+  public:
+    // 調光モードを Gaming に設定する
+    void set_mode_gaming(typename T_MoePCB_Params::LED::led_index_t led_idx, uint8_t phase_shift, uint8_t step = 6, BrightnessLevel::type_t brightness_level = 1) {
+      void * const p = this->allocateInterface(led_idx);
+      new(p) SpecificInterface(phase_shift, step, brightness_level);
+    }
+
+    // 調光モード Gaming の調光モジュールインターフェースを取得する
+    // 調光モードが Gaming 以外の場合は nullptr が返る
+    SpecificInterface* get_interface_gaming(typename T_MoePCB_Params::LED::led_index_t led_idx) {
+      auto const pBase = this->getInterface(led_idx);
+      if (pBase == nullptr) { return nullptr; }
+      auto const pI = reinterpret_cast<SpecificInterface *>(pBase);
+      if (pBase->identifier() == (void *) IdValue) {
+        return pI;
+      } else {
+        return nullptr;
+      }
+    }
+  };
+};
+
+#endif

--- a/src/Modules/LED/ColorCalculator/Icy.h
+++ b/src/Modules/LED/ColorCalculator/Icy.h
@@ -1,0 +1,232 @@
+/*!
+ * Modules/LED/ColorCalculator/Icy.h - Library for Moe-PCB (Moe Kiban)
+ *
+ * Copyright (c) 2022-2023 Mizuhasi Yukkie, Onozawa Hiro
+ * Released under the MIT license.
+ * see https://opensource.org/licenses/MIT
+ */
+
+#ifndef Modules_LED_ColorCalculator_Icy_h
+#define Modules_LED_ColorCalculator_Icy_h
+
+#include "Base.h"
+#include <new>
+
+// 白色点灯 + 寒色でランダム点滅
+class MoePCB_LEDColorCalculator_Icy
+{
+private:
+  // クラスを識別するための固有の定数
+  // TODO: 適当な関数の配置先アドレス等コンパイル時に一意に定まる値を流用したい (コンパイラの警告に引っかかるため出来ていない)
+  static constexpr uintptr_t IdValue = 0x40;
+
+public:
+  // 点灯モード
+  // Natural : ナチュラルキラキラ
+  // Digital : デジタル的
+  class Mode
+  {
+    friend class MoePCB_LEDColorCalculator_Icy;
+
+  public:
+    typedef uint8_t type_t;
+
+  public:
+    static constexpr type_t Natural = 0; // A : ナチュラルキラキラ
+    static constexpr type_t Digital = 1; // B : デジタル的
+
+  private:
+    static constexpr type_t RequireBits = 1; // 内部用 : 必要なビット幅
+  };
+
+  // 明るさレベル
+  class BrightnessLevel {
+    friend class MoePCB_LEDColorCalculator_Icy;
+
+  public:
+    typedef uint8_t type_t;
+
+  private:
+    static constexpr type_t RequireBits = 2; // 内部用 : 必要なビット幅
+  };
+
+public:
+  // LED調光モジュール個別インターフェース
+  class SpecificInterface : public MoePCB_LEDColorCalculator_SpecificInterfaceBase
+  {
+  private:
+    // 連続して同じLEDをピカピカしないよう、インターバルを設定
+    typedef uint8_t twinkle_interval_t;
+    static constexpr twinkle_interval_t twinkle_cooltime = 32;
+
+    // 明るさレベルに応じた輝度
+#if __cpp_constexpr >= 201304
+    // C++14以降向け (こちらの実装でもビルド、実行できるが警告が出る)
+    // cite: https://cpprefjp.github.io/lang/cpp14/relaxing_constraints_on_constexpr.html
+    static inline constexpr uint8_t BrightnessTable[4] = {  3, 10,  20,  30 }; // 通常輝度
+    static inline constexpr uint8_t TwinkleTable[4]    = { 40, 65, 165, 255 }; // ランダムきらきら輝度
+    constexpr uint8_t GetBrightness(BrightnessLevel::type_t brightness_level) { return BrightnessTable[brightness_level]; }
+    constexpr uint8_t GetTwinkleBrightness(BrightnessLevel::type_t brightness_level) { return TwinkleTable[brightness_level]; }
+#else
+    constexpr uint8_t GetBrightness(BrightnessLevel::type_t brightness_level) {
+      // 基本光量
+      switch (brightness_level) {
+        case 0: return 3;
+        case 1: return 10;
+        case 2: return 20;
+        case 3: return 30;
+        default: return 0;
+      }
+    }
+    constexpr uint8_t GetTwinkleBrightness(BrightnessLevel::type_t brightness_level) {
+      // ランダムきらきら輝度
+      switch (brightness_level) {
+        case 0: return 40;
+        case 1: return 65;
+        case 2: return 165;
+        case 3: return 255;
+        default: return 0;
+      }
+    }
+#endif
+
+  public:
+    SpecificInterface() = delete;
+    SpecificInterface(Mode::type_t mode, BrightnessLevel::type_t brightness_level)
+      : mode(mode)
+      , brightness_level(brightness_level)
+      , twinkle_interval(random(0, twinkle_cooltime))
+      , last_V(GetBrightness(brightness_level))
+      , last_S(0)
+      , last_H(random(25500, 45500)) // 水色〜青のランダム色
+    { }
+    ~SpecificInterface() = default;
+
+  private:
+    color_t update_sub(uint8_t rand_max, uint8_t V_default, uint8_t V_min, uint8_t V_max) {
+      uint8_t  V = V_default; // 輝度
+      uint16_t H = last_H;    // 色相
+      uint8_t  S = 0;         // 彩度
+      bool forceV = false;    // 輝度強制変更
+      bool forceS = false;    // 彩度強制変更
+
+      // 連続して同じLEDをピカピカしないように考慮
+      if (twinkle_interval > 0) {
+        --twinkle_interval;
+      }
+      else {
+        if (random(0, rand_max) == 0) {
+          V = random(V_min, V_max); //明るさを範囲でランダムで変更
+          if (mode == Mode::Digital) { last_V = V; }
+          if (random(0, 100) < 95) { // 95/100の確率で水色系のランダム色
+            H = random(25500, 45500); // 水色〜青のランダム色
+            // ランダムに彩度を決定
+            // 元実装はフィルタ処理の最後にconstrainするまでfloat範囲なのでここで256以上を返せる
+            // 新実装ではフィルタ処理の彩度減衰ペースを落とすことで見た目を近づける
+            const auto s = random(210, 330);
+            S = (s >= 256) ? 255 : ((uint8_t)s); // int 範囲から uint8_t 範囲へ縮小
+          } else { // 5/100の確率で黄色
+            H = 7650; // 稀に黄色
+            S = 180;// 黄色の時は彩度少し抑える
+          }
+
+          twinkle_interval = twinkle_cooltime;
+          last_S = S;
+          last_H = H;
+          forceV = true;
+          forceS = true;
+        }
+      }
+
+      if (mode == Mode::Digital) {
+        V = last_V;
+        S = last_S;
+        forceV = true;
+        forceS = true;
+      }
+
+      // 輝度反映
+      V = (V * this->brightness) / 256;
+
+      return color_t(H, S, V, false, forceS, forceV);
+    }
+
+  protected:
+    void* identifier() const override { return (void *) IdValue; }
+    void begin() override { }
+    void end() override { }
+
+    color_t update() override
+    {
+      switch (mode) {
+        case Mode::Natural:
+          // 点灯モード Natural : ランダムに輝度を変更
+          return update_sub(200, GetBrightness(brightness_level), GetTwinkleBrightness(brightness_level), GetTwinkleBrightness(brightness_level));
+        case Mode::Digital:
+          // 点灯モード Digital : ランダムに輝度を変更
+          return update_sub(50, GetBrightness(brightness_level), GetBrightness(brightness_level), GetTwinkleBrightness(brightness_level));
+      }
+    }
+
+  public:
+    // 点灯モードを取得
+    Mode::type_t get_mode() const { return mode; }
+    // 点灯モードを設定
+    void set_mode(Mode::type_t v) { mode = v; }
+
+    // 明るさレベル最大値を取得
+    static constexpr BrightnessLevel::type_t get_max_brightness_level() {
+#if __cpp_constexpr >= 201304
+      return sizeof(BrightnessTable)/sizeof(BrightnessTable[0]) - 1;
+#else
+      return 4 - 1;
+#endif
+    }
+    // 明るさレベルを取得
+    BrightnessLevel::type_t get_brightness_level(void) const { return brightness_level; }
+    // 明るさレベルを設定
+    void set_brightness_level(BrightnessLevel::type_t level) {
+      if (level <= get_max_brightness_level()) {
+        brightness_level = level;
+      }
+    }
+
+  private:
+    // 初期化で与える値
+    Mode::type_t mode : Mode::RequireBits; // 点灯モード
+    BrightnessLevel::type_t brightness_level : BrightnessLevel::RequireBits; // 明るさレベル
+
+    // 自動で更新する値
+    twinkle_interval_t twinkle_interval;
+    uint8_t last_V; // V 輝度
+    uint8_t last_S; // S 彩度
+    uint16_t last_H; // H 色相
+  };
+
+  // LED調光モジュールクラス用インターフェース
+  template<class T_MoePCB_Params>
+  class ModuleInterface : public MoePCB_LEDColorCalculator_ModuleInterfaceBase<T_MoePCB_Params>
+  {
+  public:
+    // 調光モードを Icy に設定する
+    void set_mode_icy(typename T_MoePCB_Params::LED::led_index_t led_idx, Mode::type_t mode = Mode::Natural, BrightnessLevel::type_t brightness_level = 1) {
+      void * const p = this->allocateInterface(led_idx);
+      new(p) SpecificInterface(mode, brightness_level);
+    }
+
+    // 調光モード Icy の調光モジュールインターフェースを取得する
+    // 調光モードが Icy 以外の場合は nullptr が返る
+    SpecificInterface* get_interface_icy(typename T_MoePCB_Params::LED::led_index_t led_idx) {
+      auto const pBase = this->getInterface(led_idx);
+      if (pBase == nullptr) { return nullptr; }
+      auto const pI = reinterpret_cast<SpecificInterface *>(pBase);
+      if (pBase->identifier() == (void *) IdValue) {
+        return pI;
+      } else {
+        return nullptr;
+      }
+    }
+  };
+};
+
+#endif

--- a/src/Modules/LED/ColorCalculator/Rainbow.h
+++ b/src/Modules/LED/ColorCalculator/Rainbow.h
@@ -61,7 +61,7 @@ public:
   private:
     // 連続して同じLEDをピカピカしないよう、インターバルを設定
     typedef uint8_t twinkle_interval_t;
-    static constexpr twinkle_interval_t twinkle_cooltime = 120;
+    static constexpr twinkle_interval_t twinkle_cooltime = 32;
 
     //明るさレベルに応じた輝度
 #if __cpp_constexpr >= 201304

--- a/src/Modules/LED/ColorCalculator/Rainbow.h
+++ b/src/Modules/LED/ColorCalculator/Rainbow.h
@@ -1,0 +1,268 @@
+/*!
+ * Modules/LED/ColorCalculator/Rainbow.h - Library for Moe-PCB (Moe Kiban)
+ *
+ * Copyright (c) 2022-2023 Mizuhasi Yukkie, Onozawa Hiro
+ * Released under the MIT license.
+ * see https://opensource.org/licenses/MIT
+ */
+
+#ifndef Modules_LED_ColorCalculator_Rainbow_h
+#define Modules_LED_ColorCalculator_Rainbow_h
+
+#include "Base.h"
+#include <new>
+
+// 基本のゆっくり虹色変化　位相差をつけるとお好みの色差で光らせられる
+class MoePCB_LEDColorCalculator_Rainbow
+{
+private:
+  // クラスを識別するための固有の定数
+  // TODO: 適当な関数の配置先アドレス等コンパイル時に一意に定まる値を流用したい (コンパイラの警告に引っかかるため出来ていない)
+  static constexpr uintptr_t IdValue = 0x50;
+
+public:
+  // 点灯モード
+  // NaturalAndTwinkle : ナチュラル (キラキラあり)
+  // DigitalAndTwinkle : デジタル的
+  // Natural : ナチュラル (キラキラなし)
+  // ForceTwinkle : 強制キラッ（MIDIとかで使う）
+  class Mode
+  {
+    friend class MoePCB_LEDColorCalculator_Rainbow;
+
+  public:
+    typedef uint8_t type_t;
+
+  public:
+    static constexpr type_t NaturalAndTwinkle = 0; // ナチュラル (キラキラあり)
+    static constexpr type_t DigitalAndTwinkle = 1; // デジタル的
+    static constexpr type_t Natural = 2;           // ナチュラル (キラキラなし)
+    static constexpr type_t ForceTwinkle = 3;      // 強制キラッ（MIDIとかで使う）
+
+  private:
+    static constexpr type_t RequireBits = 2; // 内部用 : 必要なビット幅
+  };
+
+  // 明るさレベル
+  class BrightnessLevel {
+    friend class MoePCB_LEDColorCalculator_Rainbow;
+
+  public:
+    typedef uint8_t type_t;
+
+  private:
+    static constexpr type_t RequireBits = 2; // 内部用 : 必要なビット幅
+  };
+
+public:
+  // LED調光モジュール個別インターフェース
+  class SpecificInterface : public MoePCB_LEDColorCalculator_SpecificInterfaceBase
+  {
+  private:
+    // 連続して同じLEDをピカピカしないよう、インターバルを設定
+    typedef uint8_t twinkle_interval_t;
+    static constexpr twinkle_interval_t twinkle_cooltime = 120;
+
+    //明るさレベルに応じた輝度
+#if __cpp_constexpr >= 201304
+    // C++14以降向け (こちらの実装でもビルド、実行できるが警告が出る)
+    // cite: https://cpprefjp.github.io/lang/cpp14/relaxing_constraints_on_constexpr.html
+    static inline constexpr uint8_t BrightnessTable[4]  = { 10,  25,  65, 175 }; // 通常輝度
+    static inline constexpr uint8_t TwinkleTable[4]     = { 40,  65, 155, 255 }; // ランダムきらきら輝度
+    static inline constexpr uint8_t MidiTwinkleTable[4] = { 65, 155, 255, 255 }; // ForceKiraKira で使う輝度
+    constexpr uint8_t GetBrightness(BrightnessLevel::type_t brightness_level) { return BrightnessTable[brightness_level]; }
+    constexpr uint8_t GetTwinkleBrightness(BrightnessLevel::type_t brightness_level) { return TwinkleTable[brightness_level]; }
+    constexpr uint8_t GetMidiBrightness(BrightnessLevel::type_t brightness_level) { return MidiTwinkleTable[brightness_level]; }
+#else
+    constexpr uint8_t GetBrightness(BrightnessLevel::type_t brightness_level) {
+      // 基本光量
+      switch (brightness_level) {
+        case 0: return 10;
+        case 1: return 25;
+        case 2: return 65;
+        case 3: return 175;
+        default: return 0;
+      }
+    }
+    constexpr uint8_t GetTwinkleBrightness(BrightnessLevel::type_t brightness_level) {
+      // ランダムきらきら輝度
+      switch (brightness_level) {
+        case 0: return 40;
+        case 1: return 65;
+        case 2: return 155;
+        case 3: return 255;
+        default: return 0;
+      }
+    }
+    constexpr uint8_t GetMidiBrightness(BrightnessLevel::type_t brightness_level) {
+      // ForceKiraKira で使う輝度
+      switch (brightness_level) {
+        case 0: return 65;
+        case 1: return 155;
+        case 2: return 255;
+        case 3: return 255;
+        default: return 0;
+      }
+    }
+#endif
+
+  public:
+    SpecificInterface() = delete;
+    SpecificInterface(int phase_shift, float step, Mode::type_t mode, BrightnessLevel::type_t brightness_level)
+      : mode(mode)
+      , brightness_level(brightness_level)
+      , twinkle_interval(random(0, twinkle_cooltime))
+      , rainbow_cnt(phase_shift)
+      , step(step)
+    { }
+    ~SpecificInterface() = default;
+
+  protected:
+    void* identifier() const override { return (void *) IdValue; }
+    void begin() override { }
+    void end() override { }
+
+    color_t update() override
+    {
+      // V 輝度
+      uint8_t V;
+      bool forceV = false;
+      {
+        V = GetBrightness(brightness_level); //基本光量
+
+        // 点灯モードでキラキラを要求されている場合の処理
+        if (mode == Mode::NaturalAndTwinkle || mode == Mode::DigitalAndTwinkle) {
+          // 連続して同じLEDをピカピカしないように考慮
+          if (twinkle_interval > 0) {
+            --twinkle_interval;
+          }
+          else {
+            if(random(0, 250) == 0){ //ランダムで明るくする
+              V = GetTwinkleBrightness(brightness_level);//キラッと光量
+              forceV = true;
+              twinkle_interval = twinkle_cooltime;
+            }
+          }
+        }
+
+        // 点灯モード ForceTwinkle の処理
+        if(mode == Mode::ForceTwinkle){//強制キラッ
+          V = GetMidiBrightness(brightness_level);//キラッと光量
+          forceV = true;
+        }
+
+        // 輝度反映
+        V = (V * this->brightness) / 256;
+      }
+
+      // H 色相
+      float H;
+      {
+        switch (mode) {
+        case Mode::NaturalAndTwinkle:
+          H = rainbow_cnt;
+          break;
+        case Mode::DigitalAndTwinkle:
+          H = (((int)rainbow_cnt)>>5 )<<5;
+          break;
+        case Mode::Natural:
+          H = rainbow_cnt;
+          break;
+        case Mode::ForceTwinkle:
+          // MEMO: 元実装でここは空だったが、サンプル全体の実装を見ると意図としてはこれで良さそう
+          // TODO: Midi用強制キラキラ対応は別モジュールの方が良さそう
+          H = rainbow_cnt;
+          break;
+        }
+      }
+
+      // S 彩度
+      uint8_t S;
+      {
+        // 最大値に固定
+        S = 255;
+      }
+
+      // 虹色用カウンタ 0-360で一周（色環と一致）
+      {
+        // 自動で色環指示値を回す
+        rainbow_cnt += step;  
+
+        // 色環が回ってしまったら一周分引く 0-360
+        if (360 < rainbow_cnt) { rainbow_cnt -= 360; }
+        // 色環が回ってしまったら一周分足す 0-360
+        if (rainbow_cnt < 0) { rainbow_cnt += 360; }
+      }
+
+      {
+        const uint16_t hue = (uint16_t) (H * (float)(65535.0 / 360.0));
+        return color_t(hue, S, V, false, false, forceV);
+      }
+    }
+
+  public:
+    // 点灯モードを取得
+    Mode::type_t get_mode() const { return mode; }
+    // 点灯モードを設定
+    void set_mode(Mode::type_t v) { mode = v; }
+
+    // 明るさレベル最大値を取得
+    static constexpr BrightnessLevel::type_t get_max_brightness_level() {
+#if __cpp_constexpr >= 201304
+      return sizeof(BrightnessTable)/sizeof(BrightnessTable[0]) - 1;
+#else
+      return 4 - 1;
+#endif
+    }
+    // 明るさレベルを取得
+    BrightnessLevel::type_t get_brightness_level(void) const { return brightness_level; }
+    // 明るさレベルを設定
+    void set_brightness_level(BrightnessLevel::type_t level) {
+      if (level <= get_max_brightness_level()) {
+        brightness_level = level;
+      }
+    }
+
+    // フレーム当たりの色相変化量を取得
+    float get_step() const { return step; }
+    // フレーム当たりの色相変化量を設定
+    void set_step(float v) { step = v; }
+
+  private:
+    // 初期化で与える値
+    Mode::type_t mode : Mode::RequireBits; // 点灯モード
+    BrightnessLevel::type_t brightness_level : BrightnessLevel::RequireBits; // 明るさレベル
+
+    // 自動で更新する値
+    twinkle_interval_t twinkle_interval;
+    float rainbow_cnt; // カウンタ　色環に一致（0-360）
+    float step; // 1フレームで色相環を回す角度
+  };
+
+  // LED調光モジュールクラス用インターフェース
+  template<class T_MoePCB_Params>
+  class ModuleInterface : public MoePCB_LEDColorCalculator_ModuleInterfaceBase<T_MoePCB_Params>
+  {
+  public:
+    // 調光モードを Rainbow に設定する
+    void set_mode_rainbow(typename T_MoePCB_Params::LED::led_index_t led_idx, float phase_shift, float step = 1.2f, Mode::type_t mode = Mode::Natural, BrightnessLevel::type_t brightness_level = 1) {
+      void * const p = this->allocateInterface(led_idx);
+      new(p) SpecificInterface(phase_shift, step, mode, brightness_level);
+    }
+
+    // 調光モード Rainbow の調光モジュールインターフェースを取得する
+    // 調光モードが Rainbow 以外の場合は nullptr が返る
+    SpecificInterface* get_interface_rainbow(typename T_MoePCB_Params::LED::led_index_t led_idx) {
+      auto const pBase = this->getInterface(led_idx);
+      if (pBase == nullptr) { return nullptr; }
+      auto const pI = reinterpret_cast<SpecificInterface *>(pBase);
+      if (pBase->identifier() == (void *) IdValue) {
+        return pI;
+      } else {
+        return nullptr;
+      }
+    }
+  };
+};
+
+#endif

--- a/src/Modules/LED/ColorCalculator/Simple.h
+++ b/src/Modules/LED/ColorCalculator/Simple.h
@@ -1,0 +1,90 @@
+/*!
+ * Modules/LED/ColorCalculator/Simple.h - Library for Moe-PCB (Moe Kiban)
+ *
+ * Copyright (c) 2022-2023 Mizuhasi Yukkie, Onozawa Hiro
+ * Released under the MIT license.
+ * see https://opensource.org/licenses/MIT
+ */
+
+#ifndef Modules_LED_ColorCalculator_Simple_h
+#define Modules_LED_ColorCalculator_Simple_h
+
+#include "Base.h"
+#include <new>
+
+// 指定色をそのまま返す
+class MoePCB_LEDColorCalculator_Simple
+{
+private:
+  // クラスを識別するための固有の定数
+  // TODO: 適当な関数の配置先アドレス等コンパイル時に一意に定まる値を流用したい (コンパイラの警告に引っかかるため出来ていない)
+  static constexpr uintptr_t IdValue = 0x60;
+
+public:
+  // LED調光モジュール個別インターフェース
+  class SpecificInterface : public MoePCB_LEDColorCalculator_SpecificInterfaceBase
+  {
+  public:
+    SpecificInterface() = default;
+    ~SpecificInterface() = default;
+
+  protected:
+    void* identifier() const override { return (void *) IdValue; }
+    void begin() override { }
+    void end() override { }
+
+    color_t update() override
+    {
+      return color_t(raw);
+    }
+
+  public:
+    // 色を取得
+    color_raw_t get_color() const { return raw; }
+    // 色を設定
+    void set_color(color_raw_t v) { raw = v; }
+
+    // 色 (色相) を取得
+    color_raw::hue_t get_color_hue() const { return raw.H; }
+    // 色 (色相) を設定
+    void set_color_hue(color_raw::hue_t v) { raw.H = v; }
+    // 色 (彩度) を取得
+    color_raw::sat_t get_color_sat() const { return raw.S; }
+    // 色 (彩度) を設定
+    void set_color_sat(color_raw::sat_t v) { raw.S = v; }
+    // 色 (輝度) を取得
+    color_raw::val_t get_color_val() const { return raw.V; }
+    // 色 (輝度) を設定
+    void set_color_val(color_raw::val_t v) { raw.V = v; }
+
+  private:
+    color_raw_t raw;
+  };
+
+  // LED調光モジュールクラス用インターフェース
+  template<class T_MoePCB_Params>
+  class ModuleInterface : public MoePCB_LEDColorCalculator_ModuleInterfaceBase<T_MoePCB_Params>
+  {
+  public:
+    // 調光モードを Simple に設定する
+    void set_mode_simple(typename T_MoePCB_Params::LED::led_index_t led_idx) {
+      void * const p = this->allocateInterface(led_idx);
+      new(p) SpecificInterface();
+    }
+
+    // 調光モード Simple の調光モジュールインターフェースを取得する
+    // 調光モードが Simple 以外の場合は nullptr が返る
+    SpecificInterface* get_interface_simple(typename T_MoePCB_Params::LED::led_index_t led_idx) {
+      auto const pBase = this->getInterface(led_idx);
+      if (pBase == nullptr) { return nullptr; }
+      auto const pI = reinterpret_cast<SpecificInterface *>(pBase);
+      if (pBase->identifier() == (void *) IdValue) {
+        return pI;
+      } else {
+        return nullptr;
+      }
+    }
+  };
+};
+
+#endif

--- a/src/Modules/LED/ColorCalculator/Sword.h
+++ b/src/Modules/LED/ColorCalculator/Sword.h
@@ -1,0 +1,301 @@
+/*!
+ * Modules/LED/ColorCalculator/Sword.h - Library for Moe-PCB (Moe Kiban)
+ *
+ * Copyright (c) 2022-2023 Mizuhasi Yukkie, Onozawa Hiro
+ * Released under the MIT license.
+ * see https://opensource.org/licenses/MIT
+ */
+
+#ifndef Modules_LED_ColorCalculator_Sword_h
+#define Modules_LED_ColorCalculator_Sword_h
+
+#include "Base.h"
+#include <new>
+
+// 緋想の剣　位相差をつけるとお好みの色差で光らせられる
+// Color によって色が変わる、 Mode によって光り方が変わる
+class MoePCB_LEDColorCalculator_Sword
+{
+private:
+  // クラスを識別するための固有の定数
+  // TODO: 適当な関数の配置先アドレス等コンパイル時に一意に定まる値を流用したい (コンパイラの警告に引っかかるため出来ていない)
+  static constexpr uintptr_t IdValue = 0x70;
+
+private:
+  // [in_min, in_max] の範囲をとる型 T の入力値 x を、型 U の範囲 [out_min, out_max] に射影する
+  // 内部計算は型 V で行い、計算結果は [Min, Max] でクリッピングされる
+  template<typename T, typename U, typename V, V Min, V Max>
+  inline static U map_base(T x, T in_min, T in_max, U out_min, U out_max) {
+    const V a = (V) x - (V) in_min;
+    const V b = (V) out_max - (V) out_min;
+    const V c = (V) in_max - (V) in_min;
+
+    if (c == 0) {
+      return Max;
+    }
+    
+    const V t = a * b / c + out_min;
+    if (t < Min) { return Min; }
+    if (t > Max) { return Max; }
+    return t;
+  }
+
+  // uint8_t の値を uint8_t の範囲に射影する
+  inline static uint8_t map_ui8toui8(uint8_t x, uint8_t in_min, uint8_t in_max, uint8_t out_min, uint8_t out_max) {
+    return map_base<uint8_t, uint8_t, int16_t, 0, 255>(x, in_min, in_max, out_min, out_max);
+  }
+
+  // uint8_t の値を uint16_t の範囲に射影する
+  inline static uint16_t map_ui8toui16(uint8_t x, uint8_t in_min, uint8_t in_max, uint16_t out_min, uint16_t out_max) {
+    return map_base<uint8_t, uint16_t, int32_t, 0, 65535>(x, in_min, in_max, out_min, out_max);
+  }
+
+public:
+  // 剣の色
+  // FireRed : 燃えるような色
+  // SkyBlue : 空色
+  class Color
+  {
+    friend class MoePCB_LEDColorCalculator_Sword;
+
+  public:
+    typedef uint8_t type_t;
+
+  public:
+    static constexpr type_t FireRed = 0; // 燃えるような色
+    static constexpr type_t SkyBlue = 1; // 空色
+
+  private:
+    static constexpr type_t RequireBits = 1; // 内部用 : 必要なビット幅
+  };
+
+  // 発光モード
+  // Default : 通常
+  // Twinkle : 流れるキラキラ
+  class Mode
+  {
+    friend class MoePCB_LEDColorCalculator_Sword;
+
+  public:
+    typedef uint8_t type_t;
+
+  public:
+    static constexpr type_t Default = 0; // 通常
+    static constexpr type_t Twinkle = 1; // 流れるキラキラ
+
+  private:
+    static constexpr type_t RequireBits = 1; // 内部用 : 必要なビット幅
+  };
+
+  // 明るさレベル
+  class BrightnessLevel {
+    friend class MoePCB_LEDColorCalculator_Sword;
+
+  public:
+    typedef uint8_t type_t;
+
+  private:
+    static constexpr type_t RequireBits = 2; // 内部用 : 必要なビット幅
+  };
+
+public:
+  // LED調光モジュール個別インターフェース
+  class SpecificInterface : public MoePCB_LEDColorCalculator_SpecificInterfaceBase
+  {
+  private:
+    // 明るさレベルに応じた輝度
+#if __cpp_constexpr >= 201304
+    // C++14以降向け (こちらの実装でもビルド、実行できるが警告が出る)
+    // cite: https://cpprefjp.github.io/lang/cpp14/relaxing_constraints_on_constexpr.html
+    static inline constexpr uint8_t BrightnessTable[4]          = { 10, 25, 65, 175 }; // 通常輝度
+    static inline constexpr uint8_t BrightnessDecreaseTable[4]  = {  9, 18, 60, 130 }; // Twinkle で下げる輝度
+    constexpr uint8_t GetBrightness(BrightnessLevel::type_t brightness_level) { return BrightnessTable[brightness_level]; }
+    constexpr uint8_t GetBrightnessDecrease(BrightnessLevel::type_t brightness_level) { return BrightnessDecreaseTable[brightness_level]; }
+#else
+    constexpr uint8_t GetBrightness(BrightnessLevel::type_t brightness_level) {
+      // 基本光量
+      switch (brightness_level) {
+        case 0: return 10;
+        case 1: return 25;
+        case 2: return 65;
+        case 3: return 175;
+        default: return 0;
+      }
+    }
+    constexpr uint8_t GetBrightnessDecrease(BrightnessLevel::type_t brightness_level) {
+      // ランダムきらきら輝度
+      switch (brightness_level) {
+        case 0: return 9;
+        case 1: return 18;
+        case 2: return 60;
+        case 3: return 130;
+        default: return 0;
+      }
+    }
+#endif
+
+  public:
+    SpecificInterface() = delete;
+    SpecificInterface(uint8_t phase_shift, Color::type_t color, Mode::type_t mode, BrightnessLevel::type_t brightness_level)
+      : color(color)
+      , mode(mode)
+      , brightness_level(brightness_level)
+      , sword_cnt(phase_shift)
+    { }
+    ~SpecificInterface() = default;
+
+  protected:
+    void* identifier() const override { return (void *) IdValue; }
+    void begin() override { }
+    void end() override { }
+
+    color_t update() override
+    {
+      const uint8_t local_sword_cnt = sword_cnt;
+
+      // V 輝度
+      uint8_t V;
+      bool forceV = true;
+      {
+        V = GetBrightness(brightness_level); //基本光量
+
+        if (mode == Mode::Twinkle){
+          //輝度少し弄る
+          const uint8_t decrease = GetBrightnessDecrease(brightness_level);
+          V -= (uint8_t)((uint16_t)local_sword_cnt * decrease / 256);
+          forceV = true;
+        }
+
+        // 輝度反映
+        V = (V * this->brightness) / 256;
+      }
+
+      // H 色相
+      uint16_t H;
+      {
+        switch (color) {
+        case Color::FireRed:
+        {
+          // local_sword_cnt = [0, 256) -> H = [1450, 10200) の折り返し
+          constexpr uint16_t s_min = 1450;
+          constexpr uint16_t s_max = 10200;
+          constexpr uint8_t threshold = 128;
+          if (local_sword_cnt < threshold) {
+            H = map_ui8toui16(local_sword_cnt, 0, threshold, s_min, s_max);
+          }else{
+            H = map_ui8toui16(local_sword_cnt, threshold, 255, s_max, s_min);
+          }
+          break;
+        }
+        case Color::SkyBlue:
+        {
+          // local_sword_cnt = [0, 256) -> H = [25500, 46400) の折り返し
+          constexpr uint16_t s_min = 25500;
+          constexpr uint16_t s_max = 46400;
+          constexpr uint8_t threshold = 128;
+          if (local_sword_cnt < threshold) {
+            H = map_ui8toui16(local_sword_cnt, 0, threshold, s_max, s_min);
+          }else{
+            H = map_ui8toui16(local_sword_cnt, threshold, 255, s_min, s_max);
+          }
+          break;
+        }
+        }
+      }
+
+      //彩度
+      uint8_t S;
+      {
+        #if 0
+        // Note: 元コードの計算式に寄せた実装
+        constexpr uint8_t s_min = 212;
+        constexpr uint8_t s_max = 255;
+        constexpr uint8_t threshold = 150;
+        if (local_sword_cnt < threshold) {
+          S = map_ui8toui8(local_sword_cnt, 0, threshold, s_max, s_min);
+        }else{
+          S = local_sword_cnt;
+        }
+        #else
+        // 自然な実装
+        constexpr uint8_t s_min = 150;
+        constexpr uint8_t s_max = 255;
+        constexpr uint8_t threshold = 150;
+        if (local_sword_cnt < threshold) {
+          S = map_ui8toui8(local_sword_cnt, 0, threshold, s_max, s_min);
+        }else{
+          S = map_ui8toui8(local_sword_cnt, threshold, 255, s_min, s_max);
+        }
+        #endif
+      }
+
+      // カウンタ更新
+      {
+        ++sword_cnt;
+      }
+
+      return color_t(H, S, V, false, false, forceV);
+    }
+
+  public:
+    // 剣の色を取得
+    Color::type_t get_color() const { return color; }
+    // 剣の色を設定
+    void set_color(Color::type_t v) { color = v; }
+
+    // 点灯モードを取得
+    Mode::type_t get_mode() const { return mode; }
+    // 点灯モードを設定
+    void set_mode(Mode::type_t v) { mode = v; }
+
+    // 明るさレベル最大値を取得
+    static constexpr BrightnessLevel::type_t get_max_brightness_level() {
+#if __cpp_constexpr >= 201304
+      return sizeof(BrightnessTable)/sizeof(BrightnessTable[0]) - 1;
+#else
+      return 4 - 1;
+#endif
+    }
+    // 明るさレベルを取得
+    BrightnessLevel::type_t get_brightness_level(void) const { return brightness_level; }
+    // 明るさレベルを設定
+    void set_brightness_level(BrightnessLevel::type_t level) {
+      if (level <= get_max_brightness_level()) {
+        brightness_level = level;
+      }
+    }
+
+  private:
+    // 初期化で与える値
+    Color::type_t color : Color::RequireBits; // 剣の色
+    Mode::type_t mode : Mode::RequireBits; // 発光モード
+    BrightnessLevel::type_t brightness_level : BrightnessLevel::RequireBits; // 明るさレベル
+
+    // 自動で更新する値
+    uint8_t sword_cnt; // カウンタ [0, 256)
+  };
+
+  // LED調光モジュールクラス用インターフェース
+  template<class T_MoePCB_Params>
+  class ModuleInterface : public MoePCB_LEDColorCalculator_ModuleInterfaceBase<T_MoePCB_Params>
+  {
+  public:
+    void set_mode_sword(typename T_MoePCB_Params::LED::led_index_t led_idx, uint8_t phase_shift, Color::type_t color, Mode::type_t mode = Mode::Default, BrightnessLevel::type_t brightness_level = 1) {
+      void * const p = this->allocateInterface(led_idx);
+      new(p) SpecificInterface(phase_shift, color, mode, brightness_level);
+    }
+
+    SpecificInterface* get_interface_sword(typename T_MoePCB_Params::LED::led_index_t led_idx) {
+      auto const pBase = this->getInterface(led_idx);
+      if (pBase == nullptr) { return nullptr; }
+      auto const pI = reinterpret_cast<SpecificInterface *>(pBase);
+      if (pBase->identifier() == (void *) IdValue) {
+        return pI;
+      } else {
+        return nullptr;
+      }
+    }
+  };
+};
+
+#endif

--- a/src/Modules/LED/ColorFilter/Default.h
+++ b/src/Modules/LED/ColorFilter/Default.h
@@ -1,0 +1,97 @@
+/*!
+ * Modules/LED/ColorFilter/Default.h - Library for Moe-PCB (Moe Kiban)
+ *
+ * Copyright (c) 2022-2023 Mizuhasi Yukkie, Onozawa Hiro
+ * Released under the MIT license.
+ * see https://opensource.org/licenses/MIT
+ */
+
+#ifndef Modules_LED_ColorFilter_Default_h
+#define Modules_LED_ColorFilter_Default_h
+
+// TODO: このインクルード削除したい
+#include <Adafruit_NeoPixel.h>
+
+// LED調光フィルタクラス (デフォルト)
+// 基本は輝度、彩度の変化をイージングして反映する
+// キラキラ変化を要求された場合はイージングせず指定値を直接反映する
+template<class T_MoePCB_Params, class T_BundledColorCalculator>
+class MoePCB_LEDColorFilter_Default
+{
+  template<template<class U_LEDParams, class U_LEDColorCalculator> class T_LEDColorFilter, class... T_LEDColorCalculators>
+  friend class MoePCB_LED_Module;
+
+protected:
+  typedef typename T_BundledColorCalculator::color_raw_t color_raw_t;
+  typedef typename T_BundledColorCalculator::color_t color_t;
+
+  typedef typename T_MoePCB_Params::LED::led_index_t led_index_t;
+  static constexpr led_index_t length = T_MoePCB_Params::LED::Length;
+
+protected:
+  MoePCB_LEDColorFilter_Default()
+    : last_color()
+    , flag(false)
+  {}
+  ~MoePCB_LEDColorFilter_Default() = default;
+
+protected:
+  // 32-bit packed WRGB value で返す
+  uint32_t filter(led_index_t led_idx, color_t color) {
+    if (flag) {
+      if (color.forceH) {
+        last_color[led_idx].H = color.H;
+      } else {
+        // color.H = (uint8_t)(last[led_idx*3+0] = step<float, 4>(last[led_idx*3+0], color.H));
+      }
+
+      if (color.forceS) {
+        last_color[led_idx].S = color.S;
+      } else {
+        const auto next = step<uint8_t, 10>(last_color[led_idx].S, color.S);
+        last_color[led_idx].S = next;
+        color.S = next;
+      }
+
+      if (color.forceV) {
+        last_color[led_idx].V = color.V;
+      } else {
+        const auto next = step<uint8_t, 10>(last_color[led_idx].V, color.V);
+        last_color[led_idx].V = next;
+        color.V = next;
+      }
+    }
+    // TODO: ここで Adafruit_NeoPixel 直接指定するのはいまいち
+    return Adafruit_NeoPixel::ColorHSV(color.H, color.S, color.V);
+  }
+
+  // フレームごとの更新処理
+  void update() { /* Nothing To Do */ }
+
+private:
+  // 現在値と目標値からこのフレームでの値を決定する
+  template<typename T, size_t N>
+  T step(T current, T target) {
+    if (current == target) {
+      return current;
+    } else if (current > target) {
+      const T diff = (current - target) / N + 1;
+      return current - diff;
+    } else {
+      const T diff = (target - current) / N + 1;
+      return current + diff;
+    }
+  }
+
+public:
+  // デフォルトLED調光フィルタの有効状態を設定する
+  void setEnabled(bool v) { flag = v; }
+  // デフォルトLED調光フィルタの有効状態を取得する
+  bool isEnabled(void) const { return flag; }
+
+private:
+  color_raw_t last_color[length];
+  bool flag;
+};
+
+#endif

--- a/src/Modules/LED/ColorFilter/Empty.h
+++ b/src/Modules/LED/ColorFilter/Empty.h
@@ -1,0 +1,38 @@
+/*!
+ * Modules/LED/ColorFilter/Empty.h - Library for Moe-PCB (Moe Kiban)
+ *
+ * Copyright (c) 2022-2023 Mizuhasi Yukkie, Onozawa Hiro
+ * Released under the MIT license.
+ * see https://opensource.org/licenses/MIT
+ */
+
+#ifndef Modules_LED_ColorFilter_Empty_h
+#define Modules_LED_ColorFilter_Empty_h
+
+// TODO: このインクルード削除したい
+#include <Adafruit_NeoPixel.h>
+
+// LED調光フィルタクラス (無)
+// 入力値に対する処理を一切行わない
+template<class T_MoePCB_Params, class T_BundledColorCalculator>
+class MoePCB_LEDColorFilter_Empty
+{
+  template<template<class U_LEDParams, class U_LEDColorCalculator> class T_LEDColorFilter, class... T_LEDColorCalculators>
+  friend class MoePCB_LED_Module;
+
+protected:
+  typedef typename T_BundledColorCalculator::color_t color_t;
+
+protected:
+  // 32-bit packed WRGB value で返す
+  uint32_t filter(uint8_t led_idx, color_t color) {
+    // 何もフィルタせずそのまま変換する
+    // TODO: ここで Adafruit_NeoPixel 直接指定するのはいまいち
+    return Adafruit_NeoPixel::ColorHSV(color.H, color.S, color.V);
+  }
+
+  // フレームごとの更新処理
+  void update() { /* Nothing To Do */ }
+};
+
+#endif

--- a/src/Modules/LED/ColorFilter/FullSet.h
+++ b/src/Modules/LED/ColorFilter/FullSet.h
@@ -1,0 +1,247 @@
+/*!
+ * Modules/LED/ColorFilter/FullSet.h - Library for Moe-PCB (Moe Kiban)
+ *
+ * Copyright (c) 2022-2023 Mizuhasi Yukkie, Onozawa Hiro
+ * Released under the MIT license.
+ * see https://opensource.org/licenses/MIT
+ */
+
+#ifndef Modules_LED_ColorFilter_FullSet_h
+#define Modules_LED_ColorFilter_FullSet_h
+
+// TODO: このインクルード削除したい
+#include <Adafruit_NeoPixel.h>
+
+// LED調光フィルタクラス (全部乗せ)
+// 萌基板で実装されていたすべてのフィルタ処理を詰めたフィルタ
+// TODO: 各フィルタをモジュール化して分割する
+template<class T_MoePCB_Params, class T_BundledColorCalculator>
+class MoePCB_LEDColorFilter_FullSet
+{
+  template<template<class U_LEDParams, class U_LEDColorCalculator> class T_LEDColorFilter, class... T_LEDColorCalculators>
+  friend class MoePCB_LED_Module;
+
+protected:
+  typedef typename T_BundledColorCalculator::color_raw_t color_raw_t;
+  typedef typename T_BundledColorCalculator::color_t color_t;
+
+  typedef typename T_MoePCB_Params::LED::led_index_t led_index_t;
+  static constexpr led_index_t length = T_MoePCB_Params::LED::Length;
+
+protected:
+  MoePCB_LEDColorFilter_FullSet()
+    : last_color()
+    , enable(false)
+    , angry(false)
+    , cold(false)
+    , heat(false)
+    , drunk(false)
+    , counters{}
+  {}
+  ~MoePCB_LEDColorFilter_FullSet() = default;
+
+protected:
+  // 32-bit packed WRGB value で返す
+  uint32_t filter(led_index_t led_idx, color_t color) {
+    if (enable) {
+      if (color.forceH) {
+        last_color[led_idx].H = color.H;
+      } else {
+        uint16_t hue = color.H;
+
+        // 怒りゲージによる色相上書き (0° ≒ 赤色)
+        hue = morph(0, hue, get_angry_counter());
+
+        // 寒さゲージによる色相上書き (約190° ≒ 水色)
+        hue = morph(34600, hue, get_cold_counter());
+
+        // 暑さゲージによる色相上書き (約353° ≒ 仄かに紫がかった赤色)
+        hue = morph(64250, hue, get_heat_counter());
+
+        // 酔いゲージによる色相上書き (約353° ≒ 仄かに紫がかった赤色)
+        hue = morph(64250, hue, get_drunk_counter());
+
+        color.H = hue;
+      }
+
+      {
+        const auto last_S = (color.forceS)? color.S : last_color[led_idx].S;
+
+        // 元実装は分母 10 だが、整数計算化し端数切り上げを導入したことで刻み幅が増大しているため、少し分母を大きくして調整
+        auto next = step<uint8_t, 24>(last_S, color.S);
+
+        // 怒り、寒さ、暑さ、酔いゲージにより彩度設定を無視して最大彩度になる
+        next = max(next, get_angry_counter());
+        next = max(next, get_cold_counter());
+        next = max(next, get_heat_counter());
+        next = max(next, get_drunk_counter());
+
+        last_color[led_idx].S = next;
+        color.S = next;
+      }
+
+      {
+        const auto last_V = (color.forceV)? color.V : last_color[led_idx].V;
+
+        // 元実装は分母 30 だが、整数計算化し端数切り上げを導入したことで刻み幅が増大しているため、少し分母を大きくして調整
+        auto next = step<uint8_t, 40>(last_V, color.V);
+
+        // 怒りゲージにより明るさ設定を無視して最大輝度になる
+        next = max(next, get_angry_counter());
+        if (get_angry_counter() > 250 && next >= get_angry_pulsation_counter()) {
+          next -= get_angry_pulsation_counter();
+        }
+
+        last_color[led_idx].V = next;
+        color.V = next;
+      }
+    }
+    // TODO: ここで Adafruit_NeoPixel 直接指定するのはいまいち
+    return Adafruit_NeoPixel::ColorHSV(color.H, color.S, color.V);
+  }
+
+  // フレームごとの更新処理
+  void update() {
+    if (enable) {
+      // 怒りゲージ更新
+      if (angry) {
+        if (get_angry_counter() < (256-6)) { get_angry_counter() += 6; }
+        else if (get_angry_counter() < (256-1)) { get_angry_counter() += 1; }
+
+        // 脈動ゲージ
+        get_angry_pulsation_counter() += 8;
+        if (get_angry_pulsation_counter() > 160) { get_angry_pulsation_counter() = 0; }
+      } else {
+        get_angry_pulsation_counter() = 0;
+        if (get_angry_counter() >= 4) { get_angry_counter() -= 4; }
+        else if (get_angry_counter() >= 1) { get_angry_counter() -= 1; }
+      }
+
+      // 寒さゲージ更新
+      if (cold) {
+        if (get_cold_counter() < (256-1)) { get_cold_counter() += 1; }
+      }else{
+        if (get_cold_counter() > 0) { get_cold_counter() -= 1; }
+      }
+
+      // 暑さゲージ更新
+      if (heat) {
+        if (get_heat_counter() < (256-1)) { get_heat_counter() += 1; }
+      }else{
+        if (get_heat_counter() > 0) { get_heat_counter() -= 1; }
+      }
+
+      // 酔いゲージ更新
+      if (drunk) {
+        if (get_drunk_counter() < (256-1)) { get_drunk_counter() += 1; }
+      }else{
+        if (get_drunk_counter() > 0) { get_drunk_counter() -= 1; }
+      }
+    }
+  }
+
+private:
+  // 現在値と目標値からこのフレームでの値を決定する
+  template<typename T, size_t N>
+  T step(T current, T target) {
+    if (current == target) {
+      return current;
+    } else if (current > target) {
+      const T diff = (current - target) / N + 1;
+      return current - diff;
+    } else {
+      const T diff = (target - current) / N + 1;
+      return current + diff;
+    }
+  }
+
+  // モーフィング関数
+  // 最終地点の色環に近い方に回す
+  // 現在値と目標値があまりに近いと計算結果がずれる
+  uint16_t morph(uint16_t target, uint16_t value, uint8_t gauge){
+    if (gauge == 0) {
+      // ゲージがゼロなら入力そのまま返す
+      return value;
+    }
+    if (gauge == 255) {
+      // ゲージが最大なら目標値をそのまま返す
+      return target;
+    }
+
+    if (target - value < 32768) {
+      // 加算して近づける
+      const uint16_t diff = target - value;
+      if (diff >= 256) {
+        // 本当は255で割るのが正解だが計算速度をとって256で割る
+        return value + diff / 256 * gauge;
+      } else {
+        // 差が小さいと乗算前に端数が切り捨てられて値が変化しないので、刻み幅16に変える
+        // diff < 16 だとやはりうまくいかなくなるが、その時はもはや目視できないだろうということで目をつぶる
+        return value + diff / 16 * (gauge / 16);
+      }
+    } else {
+      // 減算して近づける
+      const uint16_t diff = value - target;
+      if (diff >= 256) {
+        // 本当は255で割るのが正解だが計算速度をとって256で割る
+        return value - diff / 256 * gauge;
+      } else {
+        // 差が小さいと乗算前に端数が切り捨てられて値が変化しないので、刻み幅16に変える
+        // diff < 16 だとやはりうまくいかなくなるが、その時はもはや目視できないだろうということで目をつぶる
+        return value - diff / 16 * (gauge / 16);
+      }
+    }
+  }
+
+public:
+  // 全部乗せLED調光フィルタの有効状態を設定する
+  void setEnabled(bool v) { enable = v; }
+  // 全部乗せLED調光フィルタの有効状態を取得する
+  bool isEnabled(void) const { return enable; }
+
+  // 全部乗せLED調光フィルタの怒りモードを設定する
+  void set_state_angry(bool v) { angry = v; }
+  // 全部乗せLED調光フィルタの怒りモードを取得する
+  bool get_state_angry(void) const { return angry; }
+
+  // 全部乗せLED調光フィルタの寒さモードを設定する
+  void set_state_cold(bool v) { cold = v; }
+  // 全部乗せLED調光フィルタの寒さモードを取得する
+  bool get_state_cold(void) const { return cold; }
+
+  // 全部乗せLED調光フィルタの暑さモードを設定する
+  void set_state_heat(bool v) { heat = v; }
+  // 全部乗せLED調光フィルタの暑さモードを取得する
+  bool get_state_heat(void) const { return heat; }
+
+  // 全部乗せLED調光フィルタの酔いモードを設定する
+  void set_state_drunk(bool v) { drunk = v; }
+  // 全部乗せLED調光フィルタの酔いモードを取得する
+  bool get_state_drunk(void) const { return drunk; }
+
+private:
+  // 怒りモードカウンタ
+  uint8_t& get_angry_counter() { return counters[0]; }
+  // 怒りモード脈動カウンタ
+  uint8_t& get_angry_pulsation_counter() { return counters[1]; }
+
+  // 寒さモードカウンタ
+  uint8_t& get_cold_counter() { return counters[2]; }
+
+  // 暑さモードカウンタ
+  uint8_t& get_heat_counter() { return counters[3]; }
+
+  // 酔いモードカウンタ
+  uint8_t& get_drunk_counter() { return counters[4]; }
+
+private:
+  color_raw_t last_color[length];
+  bool enable : 1;
+  bool angry : 1;
+  bool cold : 1;
+  bool heat : 1;
+  bool drunk : 1;
+  uint8_t counters[5];
+};
+
+#endif

--- a/src/Modules/LED/Instance.h
+++ b/src/Modules/LED/Instance.h
@@ -1,0 +1,44 @@
+/*!
+ * Modules/LED/Instance.h - Library for Moe-PCB (Moe Kiban)
+ *
+ * Copyright (c) 2022-2023 Mizuhasi Yukkie, Onozawa Hiro
+ * Released under the MIT license.
+ * see https://opensource.org/licenses/MIT
+ */
+
+#ifndef Modules_LED_Instance_h
+#define Modules_LED_Instance_h
+
+#include <Adafruit_NeoPixel.h>
+
+// メインLED
+// Adafruit_NeoPixel が並んでいる
+// 配置先のピンが固定であることを前提に一部のメンバを削除し、残りは手を加えず再利用
+template<typename T_MoePCB_Params>
+class MoePCB_LED_Base
+  : public Adafruit_NeoPixel
+{
+  template<template<class U_LEDParams, class U_LEDColorCalculator> class T_LEDColorFilter, class... T_LEDColorCalculators>
+  friend class MoePCB_LED_Module;
+
+public:
+  typedef typename T_MoePCB_Params::LED::Placement placement_t;
+
+protected:
+  MoePCB_LED_Base()
+    : Adafruit_NeoPixel(T_MoePCB_Params::LED::Length, T_MoePCB_Params::LED::Port)
+  { }
+  MoePCB_LED_Base(const MoePCB_LED_Base&) = delete;
+  MoePCB_LED_Base(MoePCB_LED_Base&&) = delete;
+  MoePCB_LED_Base& operator= (const MoePCB_LED_Base&) = delete;
+  MoePCB_LED_Base& operator= (MoePCB_LED_Base&&) = delete;
+  ~MoePCB_LED_Base() = default;
+
+protected:
+  void begin(void) { Adafruit_NeoPixel::begin(); }
+  void updateLength(uint16_t n) = delete;
+  void setPin(int16_t p) = delete;
+  void updateType(neoPixelType t) = delete;
+};
+
+#endif

--- a/src/Modules/LED/Main.h
+++ b/src/Modules/LED/Main.h
@@ -1,0 +1,330 @@
+/*!
+ * Modules/LED/Main.h - Library for Moe-PCB (Moe Kiban)
+ *
+ * Copyright (c) 2022-2023 Mizuhasi Yukkie, Onozawa Hiro
+ * Released under the MIT license.
+ * see https://opensource.org/licenses/MIT
+ */
+
+#ifndef Modules_LED_Main_h
+#define Modules_LED_Main_h
+
+#include "Instance.h"
+
+#include "ColorCalculator/Base.h"
+#include "ColorCalculator/Simple.h"
+#include "ColorCalculator/Gaming.h"
+#include "ColorCalculator/Rainbow.h"
+#include "ColorCalculator/Breath.h"
+#include "ColorCalculator/Icy.h"
+#include "ColorCalculator/Autumn.h"
+#include "ColorCalculator/Sword.h"
+
+#include "ColorFilter/Empty.h"
+#include "ColorFilter/Default.h"
+#include "ColorFilter/FullSet.h"
+
+template<template<class U_LEDParams, class U_LEDColorCalculator> class T_LEDColorFilter, class... T_LEDColorCalculators>
+class MoePCB_LED_Module {
+public:
+  template<class T_MoePCB_Params>
+  class Module;
+
+private:
+  template<class T_MoePCB_Params>
+  class InnerClass;
+
+private:
+  // 1つ以上の ColorCalculator を1つに集約したクラス
+  template<class T_MoePCB_Params, class T_ColorCalculator_Head, class... T_ColorCalculator_Tail>
+  class BundledColorCalculator
+    : public T_ColorCalculator_Head::template ModuleInterface<T_MoePCB_Params>
+    , public T_ColorCalculator_Tail::template ModuleInterface<T_MoePCB_Params>...
+  {
+    friend InnerClass<T_MoePCB_Params>;
+
+  private:
+    // クラス内専用計算関数隠蔽クラス
+    class Util {
+    public:
+      // 最大値を求める (引数長 0 のとき)
+      static constexpr size_t get_max(void) { return 0; }
+
+      // 最大値を求める (引数長 1 以上のとき)
+      template <class T, class... U>
+      static constexpr size_t get_max(T a, U... b)
+      {
+        return (a > get_max(b...)) ? a : get_max(b...);
+      }
+    };
+
+  private:
+    // TODO: T_ColorCalculator_Head, T_ColorCalculator_Tail がすべて同じ型を利用している保証をする
+    typedef typename T_MoePCB_Params::LED::led_index_t led_index_t;
+  public:
+    typedef typename T_ColorCalculator_Head::SpecificInterface::color_raw color_raw_t;
+    typedef typename T_ColorCalculator_Head::SpecificInterface::color color_t;
+
+  private:
+    // T_ColorCalculator_Tail で渡された派生クラスのそれぞれのサイズのうち、最も大きい値
+    static constexpr size_t max_base_size = Util::get_max(
+      sizeof(typename T_ColorCalculator_Head::SpecificInterface),
+      sizeof(typename T_ColorCalculator_Tail::SpecificInterface)...);
+
+    // 搭載しているLED個数
+    static constexpr led_index_t length = T_MoePCB_Params::LED::Length;
+
+    // アロケート済みフラグ配列のサイズ
+    static constexpr size_t allocated_flag_array_length = (length + (8 - 1)) / 8;
+
+  protected:
+    BundledColorCalculator() = default;
+    BundledColorCalculator(const BundledColorCalculator&) = delete;
+    BundledColorCalculator(BundledColorCalculator&&) = delete;
+    BundledColorCalculator& operator= (const BundledColorCalculator&) = delete;
+    BundledColorCalculator& operator= (BundledColorCalculator&&) = delete;
+    ~BundledColorCalculator() = default;
+
+  protected:
+    void begin() {
+      for (uint8_t i = 0; i < allocated_flag_array_length; ++i) {
+        interfaces_allocated[i] = 0;
+      }
+      for (uint8_t i = 0; i < allocated_flag_array_length; ++i) {
+        interfaces_enabled[i] = 0;
+      }
+      for (size_t i = 0; i < max_base_size * length; ++i) {
+        memory_space[i] = 0;
+      }
+    }
+    void end() {
+      this->clear_all();
+    }
+
+  public:
+    // すべてのLED調光設定を削除
+    void clearModeAll() {
+      for (led_index_t i = 0; i < length; ++i) {
+        this->deleteInterface(i);
+      }
+    }
+    // LED調光設定を削除
+    void clearMode(led_index_t led_idx) {
+      this->deleteInterface(led_idx);
+    }
+
+  public:
+    // すべてのLED調光設定の輝度を変更
+    void setBrightnessAll(uint8_t brightness) {
+      for (led_index_t i = 0; i < length; ++i) {
+        this->setBrightness(i, brightness);
+      }
+    }
+    // LED調光設定の輝度を変更
+    void setBrightness(led_index_t led_idx, uint8_t brightness) {
+      auto const pI = this->getInterface(led_idx);
+      if (pI == nullptr) { return; }
+      pI->setBrightness(brightness);
+    }
+
+    // LED調光設定の有効化状態を確認
+    bool isEnabled(led_index_t led_idx) const {
+      const uint8_t idx = led_idx / 8;
+      const uint8_t bit = 1 << (led_idx % 8);
+      return interfaces_enabled[idx] & bit;
+    }
+
+    // すべてのLED調光設定の有効化状態を設定
+    void setEnabledAll(bool state) {
+      for (uint8_t i = 0; i < allocated_flag_array_length; ++i) {
+        if (state) {
+          interfaces_enabled[i] = 0xff;
+        } else {
+          interfaces_enabled[i] = 0;
+        }
+      }
+    }
+    // LED調光設定の有効化状態を設定
+    void setEnabled(led_index_t led_idx, bool state) {
+      const uint8_t idx = led_idx / 8;
+      const uint8_t bit = 1 << (led_idx % 8);
+      if (state) {
+        interfaces_enabled[idx] |= bit;
+      } else {
+        interfaces_enabled[idx] &= ~bit;
+      }
+    }
+
+  protected:
+    // LED調光モジュールがアロケート済みか確認
+    bool isAllocated(led_index_t led_idx) const {
+      const uint8_t idx = led_idx / 8;
+      const uint8_t bit = 1 << (led_idx % 8);
+      return interfaces_allocated[idx] & bit;
+    }
+
+  private:
+    // LED調光モジュールがアロケート済みであると設定する (malloc 相当)
+    bool setAllocated(led_index_t led_idx) {
+      const uint8_t idx = led_idx / 8;
+      const uint8_t bit = 1 << (led_idx % 8);
+      return interfaces_allocated[idx] |= bit;
+    }
+    // LED調光モジュールが解放済みであると設定する (free 相当)
+    bool clearAllocated(led_index_t led_idx) {
+      const uint8_t idx = led_idx / 8;
+      const uint8_t bit = 1 << (led_idx % 8);
+      return interfaces_allocated[idx] &= ~bit;
+    }
+
+    // LED調光モジュールをデストラクトし、メモリを開放する (delete 相当)
+    void deleteInterface(led_index_t led_idx) {
+      auto const pI = getInterface(led_idx);
+      if (pI == nullptr) { return; }
+      pI->~MoePCB_LEDColorCalculator_SpecificInterfaceBase();
+      this->clearAllocated(led_idx);
+    }
+
+  protected:
+    // アロケートのみ行いアドレスを返す
+    void* allocateInterface(led_index_t led_idx) override {
+      this->deleteInterface(led_idx);
+      this->setAllocated(led_idx);
+      return &memory_space[max_base_size * led_idx];
+    }
+
+    // アドレス取得のみ行う
+    MoePCB_LEDColorCalculator_SpecificInterfaceBase* getInterface(led_index_t led_idx) override {
+      if (!this->isAllocated(led_idx)) {
+        return nullptr;
+      }
+      void * const p = &memory_space[max_base_size * led_idx];
+      return reinterpret_cast<MoePCB_LEDColorCalculator_SpecificInterfaceBase*>(p);
+    }
+
+  private:
+    // interface がアロケート済みか判定するフラグ列
+    uint8_t interfaces_allocated[allocated_flag_array_length];
+    // interface の update を行うか決定するフラグ列
+    uint8_t interfaces_enabled[allocated_flag_array_length];
+
+    // MoePCB_LED_Interface 用のメモリ領域
+    // MoePCB_LED_Interfaces で渡された派生クラスの
+    // いずれであっても確実に保持できるようなメモリサイズにしている
+    unsigned char memory_space[max_base_size * length];
+  };
+
+private:
+  // モジュールの内部インターフェースを持つクラス
+  template<class T_MoePCB_Params>
+  class InnerClass {
+    friend Module<T_MoePCB_Params>;
+
+  private:
+    typedef MoePCB_LED_Base<T_MoePCB_Params> led_base_t;
+    typedef BundledColorCalculator<T_MoePCB_Params, T_LEDColorCalculators...> color_calculator_t;
+    typedef T_LEDColorFilter<T_MoePCB_Params, BundledColorCalculator<T_MoePCB_Params, T_LEDColorCalculators...>> color_filter_t;
+    typedef typename T_MoePCB_Params::LED::led_index_t led_index_t;
+
+  protected:
+    InnerClass() = default;
+    InnerClass(const InnerClass &) = delete;
+    InnerClass(InnerClass &&) = delete;
+    InnerClass& operator= (const InnerClass &) = delete;
+    InnerClass& operator= (InnerClass &&) = delete;
+    ~InnerClass() = default;
+
+  protected:
+    inline void preBegin() { }
+    inline void begin() {
+      raw_led.begin();
+      color_calculator.begin();
+    }
+    inline void postBegin() { }
+
+    inline void preEnd() { }
+    inline void end() {
+      raw_led.end();
+      color_calculator.end();
+    }
+    inline void postEnd() { }
+
+    inline void preUpdate() { }
+    inline void update() { }
+    inline void postUpdate() { }
+
+    inline void preInterrupt() { }
+    inline void interrupt() {
+      bool need_show = false;
+      for (led_index_t led_idx = 0; led_idx < T_MoePCB_Params::LED::Length; ++led_idx) {
+        if (color_calculator.isEnabled(led_idx)) {
+          auto const pI = color_calculator.getInterface(led_idx);
+          if (pI == nullptr) { continue; }
+          const auto filtered_color = color_filter.filter(led_idx, pI->update());
+          raw_led.setPixelColor((uint16_t) led_idx, filtered_color);
+          need_show = true;
+        }
+      }
+      if (need_show) {
+        raw_led.show();
+      }
+      color_filter.update();
+    }
+    inline void postInterrupt() { }
+
+  public:
+    // LEDを直接制御するための Adafruit_NeoPixel 相当のインスタンスを取得する
+    led_base_t& getRawLED() { return this->raw_led; }
+
+    // LEDの色計算モジュールのインスタンスを取得する
+    color_calculator_t& getColorCalculator() { return this->color_calculator; }
+
+    // LEDの色調整モジュールのインスタンスを取得する
+    color_filter_t& getColorFilter() { return this->color_filter; }
+
+  private:
+    led_base_t raw_led;
+    color_calculator_t color_calculator;
+    color_filter_t color_filter;
+  };
+
+public:
+  // モジュールの公開インターフェースを持つクラス
+  template<class T_MoePCB_Params>
+  class Module
+  {
+  protected:
+    Module() = default;
+    Module(const Module &) = delete;
+    Module(Module &&) = delete;
+    Module& operator= (const Module &) = delete;
+    Module& operator= (Module &&) = delete;
+    ~Module() = default;
+
+  public:
+    // LEDモジュールのインスタンスを取得する
+    inline InnerClass<T_MoePCB_Params>& getMainLED() { return inner_instance; }
+
+  protected:
+    inline void preBegin() { inner_instance.preBegin(); }
+    inline void begin() { inner_instance.begin(); }
+    inline void postBegin() { inner_instance.postBegin(); }
+
+    inline void preEnd() { inner_instance.preEnd(); }
+    inline void end() { inner_instance.end(); }
+    inline void postEnd() { inner_instance.postEnd(); }
+
+    inline void preUpdate() { inner_instance.preUpdate(); }
+    inline void update() { inner_instance.update(); }
+    inline void postUpdate() { inner_instance.postUpdate(); }
+
+    inline void preInterrupt() { inner_instance.preInterrupt(); }
+    inline void interrupt() { inner_instance.interrupt(); }
+    inline void postInterrupt() { inner_instance.postInterrupt(); }
+
+  private:
+    InnerClass<T_MoePCB_Params> inner_instance;
+  };
+};
+
+#endif

--- a/src/Modules/SubLED/Main.h
+++ b/src/Modules/SubLED/Main.h
@@ -1,0 +1,120 @@
+/*!
+ * Modules/SubLED/Main.h - Library for Moe-PCB (Moe Kiban)
+ *
+ * Copyright (c) 2022-2023 Mizuhasi Yukkie, Onozawa Hiro
+ * Released under the MIT license.
+ * see https://opensource.org/licenses/MIT
+ */
+
+#ifndef Modules_SubLED_Main_h
+#define Modules_SubLED_Main_h
+
+#include <Arduino.h>
+
+// 背面 ステータスLED
+class MoePCB_SubLEDModule {
+public:
+  template<class T_MoePCB_Params>
+  class Module;
+
+private:
+  // モジュールの内部インターフェースを持つクラス
+  template<class T_MoePCB_Params>
+  class InnerClass {
+    friend Module<T_MoePCB_Params>;
+
+  private:
+    typedef typename T_MoePCB_Params::SubLED::pin_t pin_t;
+
+  private:
+    static constexpr pin_t pin = T_MoePCB_Params::SubLED::Pin;
+
+  protected:
+    InnerClass()
+      : state(false)
+    { }
+    InnerClass(const InnerClass&) = delete;
+    InnerClass(InnerClass&&) = delete;
+    InnerClass& operator= (const InnerClass&) = delete;
+    InnerClass& operator= (InnerClass&&) = delete;
+    ~InnerClass() = default;
+
+  protected:
+    inline void preBegin() {
+      pinMode(pin, OUTPUT);
+
+      set(true);
+      show();
+    }
+    inline void begin() { }
+    inline void postBegin() { clear(); }
+
+    inline void preEnd() { }
+    inline void end() { }
+    inline void postEnd() { }
+
+    inline void preUpdate() { }
+    inline void update() { }
+    inline void postUpdate() { }
+
+    inline void preInterrupt() { }
+    inline void interrupt() { }
+    inline void postInterrupt() { }
+
+  public:
+    // 点灯状態指定 (show を呼び出すまで反映されない)
+    inline void set(bool v) { this->state = v; }
+
+    // 点灯状態取得 (実際の点灯状態ではなく内部的に指定している状態を返す)
+    inline bool get() const { return this->state; }
+
+    // 点灯状態反映
+    inline void show() { digitalWrite(pin, (this->state) ? LOW : HIGH); }
+
+    // 消灯 (直ちに消灯する)
+    inline void clear() { set(false); show(); }
+
+  private:
+    bool state : 1;
+  };
+
+public:
+  // モジュールの公開インターフェースを持つクラス
+  template<class T_MoePCB_Params>
+  class Module
+  {
+  protected:
+    Module() = default;
+    Module(const Module &) = delete;
+    Module(Module &&) = delete;
+    Module& operator= (const Module &) = delete;
+    Module& operator= (Module &&) = delete;
+    ~Module() = default;
+
+  public:
+    // サブLEDモジュールのインスタンスを取得する
+    inline InnerClass<T_MoePCB_Params>& getSubLED() { return inner_instance; }
+
+  protected:
+    inline void preBegin() { inner_instance.preBegin(); }
+    inline void begin() { inner_instance.begin(); }
+    inline void postBegin() { inner_instance.postBegin(); }
+
+    inline void preEnd() { inner_instance.preEnd(); }
+    inline void end() { inner_instance.end(); }
+    inline void postEnd() { inner_instance.postEnd(); }
+
+    inline void preUpdate() { inner_instance.preUpdate(); }
+    inline void update() { inner_instance.update(); }
+    inline void postUpdate() { inner_instance.postUpdate(); }
+
+    inline void preInterrupt() { inner_instance.preInterrupt(); }
+    inline void interrupt() { inner_instance.interrupt(); }
+    inline void postInterrupt() { inner_instance.postInterrupt(); }
+
+  private:
+    InnerClass<T_MoePCB_Params> inner_instance;
+  };
+};
+
+#endif

--- a/src/Modules/Thermometer/Main.h
+++ b/src/Modules/Thermometer/Main.h
@@ -1,0 +1,147 @@
+/*!
+ * Modules/Thermometer/Main.h - Library for Moe-PCB (Moe Kiban)
+ *
+ * Copyright (c) 2022-2023 Mizuhasi Yukkie, Onozawa Hiro
+ * Released under the MIT license.
+ * see https://opensource.org/licenses/MIT
+ */
+
+#ifndef Modules_Thermometer_Main_h
+#define Modules_Thermometer_Main_h
+
+#include <Arduino.h>
+
+class MoePCB_ThermometerModule {
+public:
+  template<class T_MoePCB_Params>
+  class Module;
+
+private:
+  // モジュールの内部インターフェースを持つクラス
+  template<class T_MoePCB_Params>
+  class InnerClass {
+    friend Module<T_MoePCB_Params>;
+
+  public:
+    typedef int16_t adc_raw_t;
+
+    // デフォルトの校正値
+    // Mizuhasi Yukkie 氏のコメントをもとにテキトーに設定
+    class DefaultReferenceData {
+    public:
+      static constexpr float Temperture[2] = { 10.0f, 18.0f };
+      static constexpr adc_raw_t ADC_Raw[2] = { 275, 295 };
+    };
+
+  protected:
+    InnerClass() = default;
+    InnerClass(const InnerClass&) = delete;
+    InnerClass(InnerClass&&) = delete;
+    InnerClass& operator= (const InnerClass&) = delete;
+    InnerClass& operator= (InnerClass&&) = delete;
+    ~InnerClass() = default;
+
+  protected:
+    static inline void preBegin() { }
+    static inline void begin() { }
+    static inline void postBegin() { }
+
+    static inline void preEnd() { }
+    static inline void end() { }
+    static inline void postEnd() { }
+
+    static inline void preUpdate() { }
+    static inline void update() { }
+    static inline void postUpdate() { }
+
+    inline void preInterrupt() { }
+    inline void interrupt() { }
+    inline void postInterrupt() { }
+
+  public:
+    // ADC の生の値を返す [0, 1023] が返る想定
+    static inline adc_raw_t getADCRaw() { return getADCRawAverage(1); }
+
+    // ADC の生の値を複数サンプリングし、平均を返す [0, 1023] が返る想定
+    static adc_raw_t getADCRawAverage(uint16_t sample) {
+      // MUX = 1 00111; 温度感知器
+      // REFS = 11;     A/D変換部の基準電圧選択に 2.56V内部基準電圧 を選択する必要がある
+      ADCSRB = _BV(MUX5);
+      ADMUX = (_BV(REFS1) | _BV(REFS0) | _BV(MUX2) | _BV(MUX1) | _BV(MUX0));
+      ADCSRA |= _BV(ADEN);
+
+      //  温度感知器の駆動部の伝播遅延は概ね2μsです。
+      //  従って2回の逐次比較が必要とされます。
+      //  正しい温度測定は2回目のそれです。
+      // とあるので、1回読み捨てる
+      ADCSRA |= _BV(ADSC); // 変換開始
+      while (bit_is_set(ADCSRA,ADSC));// 変換終了
+
+      int32_t _value = 0;
+      for(uint16_t _counter = 0; _counter < sample; _counter++)
+      {
+        ADCSRA |= _BV(ADSC); // 変換開始
+        while (bit_is_set(ADCSRA,ADSC));// 変換終了
+
+        _value += ADCW;
+      }
+
+      // Commented by Mizuhasi Yukkie :
+      // 室温 294.0-306.0くらい 電源入れた直後は289.0とか
+      // 冷蔵庫に少し入れたあと 274.0-277.0
+      return static_cast<adc_raw_t>(_value / sample);
+    }
+
+    // ADC の生の値を温度に変換する
+    // Reference : 校正済みの基準データ、基準温度とその時の adcRaw の値のペアを2組持たせる
+    template<class Reference = DefaultReferenceData>
+    static float convertADCRawToTemperature(adc_raw_t adcRaw){
+      constexpr float diffTemperature = Reference::Temperture[1] - Reference::Temperture[0];
+      constexpr adc_raw_t diffADCRaw = Reference::ADC_Raw[1] - Reference::ADC_Raw[0];
+
+      constexpr float trend = diffADCRaw / diffTemperature;
+      constexpr float offset = Reference::Volatage[1] - Reference::Temperture[1] * trend;
+
+      return (adcRaw - offset) / trend;
+    }
+  };
+
+public:
+  // モジュールの公開インターフェースを持つクラス
+  template<class T_MoePCB_Params>
+  class Module {
+  protected:
+    Module() = default;
+    Module(const Module&) = delete;
+    Module(Module&&) = delete;
+    Module& operator= (const Module&) = delete;
+    Module& operator= (Module&&) = delete;
+    ~Module() = default;
+
+  public:
+    // 温度計モジュールのインスタンスを取得する
+    inline InnerClass<T_MoePCB_Params>& getThermometer() { return inner_instance; }
+
+  protected:
+    inline void preBegin() { inner_instance.preBegin(); }
+    inline void begin() { inner_instance.begin(); }
+    inline void postBegin() { inner_instance.postBegin(); }
+
+    inline void preEnd() { inner_instance.preEnd(); }
+    inline void end() { inner_instance.end(); }
+    inline void postEnd() { inner_instance.postEnd(); }
+
+    inline void preUpdate() { inner_instance.preUpdate(); }
+    inline void update() { inner_instance.update(); }
+    inline void postUpdate() { inner_instance.postUpdate(); }
+
+    inline void preInterrupt() { inner_instance.preInterrupt(); }
+    inline void interrupt() { inner_instance.interrupt(); }
+    inline void postInterrupt() { inner_instance.postInterrupt(); }
+
+  private:
+    InnerClass<T_MoePCB_Params> inner_instance;
+  };
+};
+
+#endif

--- a/src/Modules/TouchSensor/Instance.cpp
+++ b/src/Modules/TouchSensor/Instance.cpp
@@ -1,0 +1,60 @@
+/*!
+ * Modules/TouchSensor/Instance.cpp - Library for Moe-PCB (Moe Kiban)
+ *
+ * Copyright (c) 2022-2023 Mizuhasi Yukkie, Onozawa Hiro
+ * Released under the MIT license.
+ * see https://opensource.org/licenses/MIT
+ */
+#include "Instance.h"
+
+#include <ADCTouch.h>
+
+void MoePCB_TouchSensor::begin()
+{
+  // ADCnピンのデジタル入力緩衝部を禁止する
+  // デジタル入力緩衝部での消費電力を削減する
+  switch (this->port) {
+    case A0: DIDR0 |= _BV(ADC7D); break;
+    case A1: DIDR0 |= _BV(ADC6D); break;
+    case A2: DIDR0 |= _BV(ADC5D); break;
+    case A3: DIDR0 |= _BV(ADC4D); break;
+    case A4: DIDR0 |= _BV(ADC1D); break;
+    case A5: DIDR0 |= _BV(ADC0D); break;
+    case A6: DIDR2 |= _BV(ADC8D); break;
+    case A7: DIDR2 |= _BV(ADC9D); break;
+    case A8: DIDR2 |= _BV(ADC10D); break;
+    case A9: DIDR2 |= _BV(ADC11D); break;
+    case A10: DIDR2 |= _BV(ADC12D); break;
+    case A11: DIDR2 |= _BV(ADC13D); break;
+  }
+
+  this-> offset = ADCTouch.read(this->port, Init_Sampling);
+}
+
+void MoePCB_TouchSensor::update() {
+  const int raw = ADCTouch.read(this->port, Update_Sampling);
+  const int sense  = raw - this->offset;
+
+  const bool isPressing = Threshold < sense;
+  const State::type_t rawState = this->state;
+  const bool isFreezing = rawState & State::Freezing;
+  const bool isLastRelease = rawState & State::On_Release;
+  const State::type_t lastPressingCnt = isLastRelease ? 0 : (rawState & State::Mask_Pressing);
+  State::type_t nextState = 0;
+
+  if (isPressing) {
+    if (isFreezing) {
+      nextState = rawState;
+    } else if (lastPressingCnt >= State::Mask_Pressing) {
+      nextState = State::Mask_Pressing;
+    } else {
+      nextState = lastPressingCnt + 1;
+    }
+  } else {
+    if (!isFreezing && lastPressingCnt > 0) {
+      nextState = lastPressingCnt | State::On_Release;
+    }
+  }
+
+  this->state = nextState;
+}

--- a/src/Modules/TouchSensor/Instance.h
+++ b/src/Modules/TouchSensor/Instance.h
@@ -1,0 +1,78 @@
+/*!
+ * Modules/TouchSensor/Instance.h - Library for Moe-PCB (Moe Kiban)
+ *
+ * Copyright (c) 2022-2023 Mizuhasi Yukkie, Onozawa Hiro
+ * Released under the MIT license.
+ * see https://opensource.org/licenses/MIT
+ */
+
+#ifndef Modules_TouchSensor_Instance_h
+#define Modules_TouchSensor_Instance_h
+
+#include <Arduino.h>
+
+// タッチセンサ 1つ
+class MoePCB_TouchSensor
+{
+public:
+  class State {
+  public:
+    typedef uint8_t type_t;
+
+  public:
+    static constexpr type_t Mask_Pressing = (1 << (sizeof(type_t) * 8 - 2)) - 1;
+    static constexpr type_t Freezing = 1 << (sizeof(type_t) * 8 - 2);
+    static constexpr type_t On_Release = 1 << (sizeof(type_t) * 8 - 1);
+  };
+
+
+private:
+  // オフセット決定時、センサ値読み取り時のサンプリング数
+  static constexpr int Init_Sampling = 500;
+  static constexpr int Update_Sampling = 20;
+
+  // スレッショルド
+  // (センサ値 - オフセット) > スレッショルドの場合タッチされたと判定する
+  static constexpr int Threshold = 50;
+
+public:
+  MoePCB_TouchSensor() = delete;
+  MoePCB_TouchSensor(uint8_t port)
+    : offset(0)
+    , state(0)
+    , port(port)
+  { }
+  MoePCB_TouchSensor(const MoePCB_TouchSensor&) = delete;
+  MoePCB_TouchSensor(MoePCB_TouchSensor&&) = default;
+  MoePCB_TouchSensor& operator= (const MoePCB_TouchSensor&) = delete;
+  MoePCB_TouchSensor& operator= (MoePCB_TouchSensor&&) = delete;
+  ~MoePCB_TouchSensor() = default;
+
+  // ステータス初期化
+  void begin();
+
+  // ステータス更新
+  void update();
+
+  // 次に押し上げされるまで更新を止める
+  inline void freezeWhilePressing() { this->state |= State::Freezing; }
+
+  // 現在のタッチ状態を取得する
+  inline State::type_t getCurrentState() { return this->state; }
+
+  // 現在タッチされているかを返す
+  inline bool isPressing() { return (this->state & State::Mask_Pressing) && !isOnRelease(); }
+  // 長押ししたフレーム数を返す
+  inline int getPressingCount() { return (int)(this->state & State::Mask_Pressing); }
+  // 立ち上がりかを返す
+  inline bool isOnTouch() { return (this->state & State::Mask_Pressing) == 1; }
+  // 立ち下がりかを返す
+  inline bool isOnRelease() { return this->state & State::On_Release; }
+
+private:
+  int offset;
+  State::type_t state;
+  uint8_t port;
+};
+
+#endif

--- a/src/Modules/TouchSensor/Main.h
+++ b/src/Modules/TouchSensor/Main.h
@@ -1,0 +1,120 @@
+/*!
+ * Modules/TouchSensor/Main.h - Library for Moe-PCB (Moe Kiban)
+ *
+ * Copyright (c) 2022-2023 Mizuhasi Yukkie, Onozawa Hiro
+ * Released under the MIT license.
+ * see https://opensource.org/licenses/MIT
+ */
+
+#ifndef Modules_TouchSensor_Main_h
+#define Modules_TouchSensor_Main_h
+
+#include "Instance.h"
+
+class MoePCB_TouchSensorModule {
+private:
+  // cite: https://lpha-z.hatenablog.com/entry/2020/04/05/231500
+  class Util {
+    template<size_t...> struct index_sequence {};
+
+    template<size_t I, size_t... Is> struct S : S<I-1, I-1, Is...> {};
+    template<size_t... Is> struct S<0, Is...> { index_sequence<Is...> f(); };
+
+    template<size_t N> using make_index_sequence = decltype(S<N>{}.f());
+  };
+
+public:
+  template<class T_MoePCB_Params>
+  class Module;
+
+private:
+  // モジュールの内部インターフェースを持つクラス
+  template<class T_MoePCB_Params, class = Util::make_index_sequence<T_MoePCB_Params::TouchSensor::Length>>
+  class InnerClass;
+
+  // モジュールの内部インターフェースを持つクラス (の特殊化)
+  template<class T_MoePCB_Params, size_t... I>
+  class InnerClass<T_MoePCB_Params, Util::index_sequence<I...>> {
+    friend Module<T_MoePCB_Params>;
+
+  private:
+    typedef typename T_MoePCB_Params::TouchSensor::touch_sensor_index_t index_t;
+
+    static constexpr index_t length = T_MoePCB_Params::TouchSensor::Length;
+
+  protected:
+    InnerClass()
+      : sensors({ T_MoePCB_Params::TouchSensor::Port::Get(I)... })
+    {}
+    InnerClass(const InnerClass&) = delete;
+    InnerClass(InnerClass&&) = delete;
+    InnerClass& operator= (const InnerClass&) = delete;
+    InnerClass& operator= (InnerClass&&) = delete;
+    ~InnerClass() = default;
+
+  public:
+    inline void preBegin() { }
+    inline void begin() { for (index_t idx = 0; idx < length; ++idx) { sensors[idx].begin(); } }
+    inline void postBegin() { }
+
+    inline void preEnd() { }
+    inline void end() { }
+    inline void postEnd() { }
+
+    inline void preUpdate() { }
+    inline void update() { for (index_t idx = 0; idx < length; ++idx) { sensors[idx].update(); } }
+    inline void postUpdate() { }
+
+    inline void preInterrupt() { }
+    inline void interrupt() { }
+    inline void postInterrupt() { }
+
+  public:
+    // タッチセンサのインスタンスを取得する
+    inline MoePCB_TouchSensor& getRawTouchSensor(index_t idx) { return sensors[idx]; }
+
+  private:
+    // MoePCB_TouchSensor のインスタンスの配列
+    MoePCB_TouchSensor sensors[length];
+  };
+
+public:
+  // モジュールの公開インターフェースを持つクラス
+  template<class T_MoePCB_Params>
+  class Module
+  {
+  protected:
+    Module() = default;
+    Module(const Module&) = delete;
+    Module(Module&&) = delete;
+    Module& operator= (const Module&) = delete;
+    Module& operator= (Module&&) = delete;
+    ~Module() = default;
+
+  public:
+    // タッチセンサモジュールのインスタンスを取得する
+    inline InnerClass<T_MoePCB_Params>& getTouchSensor() { return inner_instance; }
+
+  protected:
+    inline void preBegin() { inner_instance.preBegin(); }
+    inline void begin() { inner_instance.begin(); }
+    inline void postBegin() { inner_instance.postBegin(); }
+
+    inline void preEnd() { inner_instance.preEnd(); }
+    inline void end() { inner_instance.end(); }
+    inline void postEnd() { inner_instance.postEnd(); }
+
+    inline void preUpdate() { inner_instance.preUpdate(); }
+    inline void update() { inner_instance.update(); }
+    inline void postUpdate() { inner_instance.postUpdate(); }
+
+    inline void preInterrupt() { inner_instance.preInterrupt(); }
+    inline void interrupt() { inner_instance.interrupt(); }
+    inline void postInterrupt() { inner_instance.postInterrupt(); }
+
+  private:
+    InnerClass<T_MoePCB_Params> inner_instance;
+  };
+};
+
+#endif

--- a/src/MoePCB.cpp
+++ b/src/MoePCB.cpp
@@ -8,15 +8,6 @@
     #include "Arduino.h"
     #include "MoePCB.h"
 
-    //タイマー４ 20-25ms割り込み
-    extern void MoePCB_Task(void);
-    ISR (TIMER4_COMPA_vect) {
-      MoePCB_Task();
-    }
-    //タイマー１版 20-25ms割り込み　※未使用
-//    ISR (TIMER1_COMPA_vect) {
-//      MoePCB_Task();
-//    }
     //コンストラクタ
     MoePCB::MoePCB(uint8_t led_num){
       _led_num = led_num; //LED数をプライベートに保存

--- a/src/MoePCB.h
+++ b/src/MoePCB.h
@@ -5,7 +5,7 @@
  * Released under the MIT license.
  * see https://opensource.org/licenses/MIT
 */
-
+#ifndef USE_NEW_MOE_PCB
     #ifndef MoePCB_h
     #define MoePCB_h
     #include "Arduino.h"
@@ -106,3 +106,6 @@
     };
 
     #endif
+#else
+#include "./NewMoePCB.h"
+#endif

--- a/src/NewMoePCB.h
+++ b/src/NewMoePCB.h
@@ -1,0 +1,21 @@
+/*!
+ * NewMoePCB.h - Library for Moe-PCB (Moe Kiban)
+ *
+ * Copyright (c) 2022-2023 Mizuhasi Yukkie, Onozawa Hiro
+ * Released under the MIT license.
+ * see https://opensource.org/licenses/MIT
+ */
+
+#ifndef NewMoePCB_h
+#define NewMoePCB_h
+
+// Core
+#include "NewMoePCB_Core.h"
+
+// Module
+#include "Modules/LED/Main.h"
+#include "Modules/SubLED/Main.h"
+#include "Modules/Thermometer/Main.h"
+#include "Modules/TouchSensor/Main.h"
+
+#endif

--- a/src/NewMoePCB_Core.h
+++ b/src/NewMoePCB_Core.h
@@ -1,0 +1,89 @@
+/*!
+ * NewMoePCB_Core.h - Library for Moe-PCB (Moe Kiban)
+ *
+ * Copyright (c) 2022-2023 Mizuhasi Yukkie, Onozawa Hiro
+ * Released under the MIT license.
+ * see https://opensource.org/licenses/MIT
+ */
+
+#ifndef NewMoePCB_Core_h
+#define NewMoePCB_Core_h
+
+#include "NewMoePCB_Timer.h"
+
+// 萌基板 本体
+// 各モジュールをまとめた構造体的な役割
+// これ自身は便利機能を提供しない
+template<class T_MoePCB_Params, class... T_MoePCB_Module>
+class MoePCB_Core
+  : public T_MoePCB_Module::template Module<T_MoePCB_Params>...
+{
+public:
+  typedef T_MoePCB_Params params_t;
+
+public:
+  MoePCB_Core() = default;
+  MoePCB_Core(const MoePCB_Core&) = delete;
+  MoePCB_Core(MoePCB_Core&&) = delete;
+  MoePCB_Core& operator= (const MoePCB_Core&) = delete;
+  MoePCB_Core& operator= (MoePCB_Core&&) = delete;
+  ~MoePCB_Core() = default;
+
+// swallow idiom
+// やっていることは T_MoePCB_Module で渡された複数の基底クラスのメンバ関数 funcName を順番に呼び出すこと
+#define MOEPCB_Macro_Swallow(funcName) do { int swallow[] = { (T_MoePCB_Module::template Module<T_MoePCB_Params>::funcName(), 0)... }; (void)&swallow; } while(0)
+
+protected:
+  // 基底クラスで定義されている(はず)のメンバ関数を呼ばれないよう削除しておく
+  void preBegin() = delete;
+  void postBegin() = delete;
+
+  void preEnd() = delete;
+  void postEnd() = delete;
+
+  void preUpdate() = delete;
+  void postUpdate() = delete;
+
+  void preInterrupt() = delete;
+  void postInterrupt() = delete;
+
+public:
+  // (コンストラクトではない) 初期化
+  inline void begin()
+  {
+    MOEPCB_Macro_Swallow(preBegin);
+    MOEPCB_Macro_Swallow(begin);
+
+    MoePCB_Timer::begin();
+    MoePCB_Timer::enable();
+
+    MOEPCB_Macro_Swallow(postBegin);
+  }
+
+  // (デストラクトではない) 破棄
+  inline void end()
+  {
+    MOEPCB_Macro_Swallow(preEnd);
+    MOEPCB_Macro_Swallow(end);
+    MOEPCB_Macro_Swallow(postEnd);
+  }
+
+  // 更新 (内部状態を更新する必要がないときは呼ばなくても問題ないもの)
+  inline void update() {
+    MOEPCB_Macro_Swallow(preUpdate);
+    MOEPCB_Macro_Swallow(update);
+    MOEPCB_Macro_Swallow(postUpdate);
+  }
+
+  // 更新 (割り込みで常に一定間隔で呼び出す必要があるもの)
+  inline void interrupt() {
+    MOEPCB_Macro_Swallow(preInterrupt);
+    MOEPCB_Macro_Swallow(interrupt);
+    MOEPCB_Macro_Swallow(postInterrupt);
+  }
+
+#undef MOEPCB_Macro_Swallow
+
+};
+
+#endif

--- a/src/NewMoePCB_Timer.cpp
+++ b/src/NewMoePCB_Timer.cpp
@@ -1,0 +1,71 @@
+/*!
+ * NewMoePCB_Timer.cpp - Library for Moe-PCB (Moe Kiban)
+ *
+ * Copyright (c) 2022-2023 Mizuhasi Yukkie, Onozawa Hiro
+ * Released under the MIT license.
+ * see https://opensource.org/licenses/MIT
+ */
+#include "NewMoePCB_Timer.h"
+
+#include <Arduino.h>
+
+void MoePCB_Timer::begin()
+{
+#if 1
+  //タイマーA：20-25msごとにコンペアAクリア＆割り込みを設定
+  TCCR4B = 0;
+  TCCR4A = 0;
+  TCCR4C = 0;
+  TCCR4D = 0;
+  TCCR4E = 0;
+  TCCR4B = 0b1100; // 1/2048
+  OCR4C = 156;     // 0-255  <-- 16,000,000 MHz / 2048 / 50Hz
+  // OCR4C =195;//0-255  <-- 16,000,000 MHz / 2048 / 40Hz
+#else
+  //タイマー1：20-25msごとにコンペアAクリア＆割り込みを設定
+  TCCR1B = 0;  TCCR1A = 0;  TCCR1C = 0;
+  TCCR1B = (1<<WGM12)|(1<<CS02)|(1<<CS00);//0b00000010;// 1/1024
+  OCR1A =312;//16bit  <-- 16,000,000 MHz / 1024 / 50Hz
+  //OCR1A =390;//16bit  <-- 16,000,000 MHz / 1024 / 40Hz
+#endif
+}
+
+void MoePCB_Timer::end()
+{
+  // FIXME: 実装する
+}
+
+void MoePCB_Timer::enable()
+{
+#if 1
+  //タイマー４開始処理
+  TIFR4 = (1 << OCF4A);
+  TCNT4 = 0;
+  TIMSK4 = (1 << OCIE4A);
+#else
+  //タイマー1開始処理
+  TIFR1 = (1<<OCF1A);
+  TCNT1 = 0;
+  TIMSK1 = (1<<OCIE1A);
+#endif
+}
+
+void MoePCB_Timer::disable()
+{
+  // FIXME: 実装する
+}
+
+
+#if 1
+//タイマー４ 20-25ms割り込み
+extern void MoePCB_Task(void);
+ISR(TIMER4_COMPA_vect)
+{
+  MoePCB_Task();
+}
+#else
+//タイマー１版 20-25ms割り込み　※未使用
+//    ISR (TIMER1_COMPA_vect) {
+//      MoePCB_Task();
+//    }
+#endif

--- a/src/NewMoePCB_Timer.h
+++ b/src/NewMoePCB_Timer.h
@@ -1,0 +1,45 @@
+/*!
+ * NewMoePCB_Timer.h - Library for Moe-PCB (Moe Kiban)
+ *
+ * Copyright (c) 2022-2023 Mizuhasi Yukkie, Onozawa Hiro
+ * Released under the MIT license.
+ * see https://opensource.org/licenses/MIT
+ */
+
+#ifndef NewMoePCB_Timer_h
+#define NewMoePCB_Timer_h
+
+#include "NewMoePCB_Timer.h"
+
+class MoePCB_Timer {
+private:
+  MoePCB_Timer() = delete;
+  MoePCB_Timer(const MoePCB_Timer&) = delete;
+  MoePCB_Timer(MoePCB_Timer&&) = delete;
+  MoePCB_Timer& operator= (const MoePCB_Timer&) = delete;
+  MoePCB_Timer& operator= (MoePCB_Timer&&) = delete;
+  ~MoePCB_Timer() = delete;
+
+public:
+  static void preBegin() { }
+  static void begin();
+  static void postBegin() { }
+
+  static void preEnd() { }
+  static void end();
+  static void postEnd() { }
+
+  static void preUpdate() { }
+  static void update() { }
+  static void postUpdate() { }
+
+  static void preInterrupt() { }
+  static void interrupt() { }
+  static void postInterrupt() { }
+
+public:
+  static void enable();
+  static void disable();
+};
+
+#endif

--- a/src/Params/Cirno.h
+++ b/src/Params/Cirno.h
@@ -1,0 +1,87 @@
+/*!
+ * Params/Cirno.h - Library for Moe-PCB (Moe Kiban)
+ *
+ * Copyright (c) 2022-2023 Mizuhasi Yukkie, Onozawa Hiro
+ * Released under the MIT license.
+ * see https://opensource.org/licenses/MIT
+ */
+
+#ifndef Params_Cirno_h
+#define Params_Cirno_h
+
+#include <stdint.h>
+#include <Arduino.h>
+
+// チルノの萌基板パラメータ
+class MoePCB_Params_Cirno
+{
+public:
+  class LED {
+  public:
+    typedef uint8_t led_index_t;
+
+  public:
+    class Placement
+    {
+    public:
+      static constexpr led_index_t Heart      = 0; // LED1 : 胸 (背面)
+      static constexpr led_index_t UpperLeft  = 1; // LED2 : 左上
+      static constexpr led_index_t Left       = 2; // LED3 : 左中
+      static constexpr led_index_t LowerLeft  = 3; // LED4 : 左下
+      static constexpr led_index_t UpperRight = 4; // LED5 : 右上
+      static constexpr led_index_t Right      = 5; // LED6 : 右中
+      static constexpr led_index_t LowerRight = 6; // LED7 : 右下
+    };
+
+  public:
+    static constexpr led_index_t Length = 7;
+    static constexpr int16_t Port = 6;
+  };
+
+  class SubLED {
+  public:
+    typedef uint8_t pin_t;
+
+  public:
+    static constexpr pin_t Pin = 13;
+  };
+
+  class Thermometer {
+
+  };
+
+  class TouchSensor {
+  public:
+    typedef uint8_t touch_sensor_port_t;
+    typedef uint8_t touch_sensor_index_t;
+
+  public:
+    // 配置場所 -> インデックス
+    class Placement
+    {
+    public:
+      static constexpr touch_sensor_index_t Hair  = 0; // タッチセンサ1 : 髪
+      static constexpr touch_sensor_index_t Chest = 1; // タッチセンサ2 : 胸
+      static constexpr touch_sensor_index_t Skirt = 2; // タッチセンサ3 : スカート
+    };
+
+    // インデックス -> 接続先ポート
+    class Port
+    {
+    public:
+      static constexpr touch_sensor_port_t Hair  = A1; // タッチセンサ1 : 髪
+      static constexpr touch_sensor_port_t Chest = A0; // タッチセンサ2 : 胸
+      static constexpr touch_sensor_port_t Skirt = A2; // タッチセンサ3 : スカート
+
+    public:
+      static constexpr touch_sensor_port_t Get(touch_sensor_index_t idx) {
+        return idx == 0 ? Hair : (idx == 1 ? Chest : (idx == 2 ? Skirt : 0));
+      }
+    };
+
+  public:
+    static constexpr touch_sensor_index_t Length = 3;
+  };
+};
+
+#endif

--- a/src/Params/Fran.h
+++ b/src/Params/Fran.h
@@ -1,0 +1,87 @@
+/*!
+ * Params/Fran.h - Library for Moe-PCB (Moe Kiban)
+ *
+ * Copyright (c) 2022-2023 Mizuhasi Yukkie, Onozawa Hiro
+ * Released under the MIT license.
+ * see https://opensource.org/licenses/MIT
+ */
+
+#ifndef Params_Fran_h
+#define Params_Fran_h
+
+#include <stdint.h>
+#include <Arduino.h>
+
+// フランの萌基板パラメータ
+class MoePCB_Params_Fran
+{
+public:
+  class LED {
+  public:
+    typedef uint8_t led_index_t;
+
+  public:
+    class Placement
+    {
+    public:
+      static constexpr led_index_t Heart      = 0; // LED1 : 胸 (背面)
+      static constexpr led_index_t OuterLeft  = 3; // LED4 : 最左
+      static constexpr led_index_t Left       = 2; // LED3 : 中左
+      static constexpr led_index_t InnerLeft  = 1; // LED2 : 内左
+      static constexpr led_index_t InnerRight = 4; // LED5 : 内右
+      static constexpr led_index_t Right      = 5; // LED6 : 中右
+      static constexpr led_index_t OuterRight = 6; // LED7 : 最右
+    };
+
+  public:
+    static constexpr led_index_t Length = 7;
+    static constexpr int16_t Port = 6;
+  };
+
+  class SubLED {
+  public:
+    typedef uint8_t pin_t;
+
+  public:
+    static constexpr pin_t Pin = 13;
+  };
+
+  class Thermometer {
+
+  };
+
+  class TouchSensor {
+  public:
+    typedef uint8_t touch_sensor_port_t;
+    typedef uint8_t touch_sensor_index_t;
+
+  public:
+    // 配置場所 -> インデックス
+    class Placement
+    {
+    public:
+      static constexpr touch_sensor_index_t Hair  = 0; // タッチセンサ1 : 髪
+      static constexpr touch_sensor_index_t Chest = 1; // タッチセンサ2 : 胸
+      static constexpr touch_sensor_index_t Skirt = 2; // タッチセンサ3 : スカート
+    };
+
+    // インデックス -> 接続先ポート
+    class Port
+    {
+    public:
+      static constexpr touch_sensor_port_t Hair  = A0; // タッチセンサ1 : 髪
+      static constexpr touch_sensor_port_t Chest = A1; // タッチセンサ2 : 胸
+      static constexpr touch_sensor_port_t Skirt = A2; // タッチセンサ3 : スカート
+
+    public:
+      static constexpr touch_sensor_port_t Get(touch_sensor_index_t idx) {
+        return idx == 0 ? Hair : (idx == 1 ? Chest : (idx == 2 ? Skirt : 0));
+      }
+    };
+
+  public:
+    static constexpr touch_sensor_index_t Length = 3;
+  };
+};
+
+#endif

--- a/src/Params/Hina.h
+++ b/src/Params/Hina.h
@@ -1,0 +1,92 @@
+/*!
+ * Params/Hina.h - Library for Moe-PCB (Moe Kiban)
+ *
+ * Copyright (c) 2022-2023 Mizuhasi Yukkie, Onozawa Hiro
+ * Released under the MIT license.
+ * see https://opensource.org/licenses/MIT
+ */
+
+#ifndef Params_Hina_h
+#define Params_Hina_h
+
+#include <stdint.h>
+#include <Arduino.h>
+
+// 雛の萌基板パラメータ
+class MoePCB_Params_Hina
+{
+public:
+  class LED {
+  public:
+    typedef uint8_t led_index_t;
+
+  public:
+    class Placement
+    {
+    public:
+      static constexpr led_index_t Heart       = 0; // LED1  : 胸 (背面)
+      static constexpr led_index_t Head        = 5; // LED6  : 頭
+      static constexpr led_index_t UpperRight  = 6; // LED7  : 右上 (リボン上)
+      static constexpr led_index_t Right       = 7; // LED8  : 右 (リボン上)
+      static constexpr led_index_t UpperLeft   = 4; // LED5  : 左上 (手元)
+      static constexpr led_index_t Left        = 3; // LED4  : 左 (リボン上)
+      static constexpr led_index_t LowerLeft   = 2; // LED3  : 左下外 (スカート上)
+      static constexpr led_index_t InnerLeft   = 1; // LED2  : 左下内 (スカート上)
+      static constexpr led_index_t InnerRight  = 9; // LED10 : 右下内 (スカート上)
+      static constexpr led_index_t LowerRight  = 8; // LED9  : 右下外 (スカート上)
+    };
+
+  public:
+    static constexpr led_index_t Length = 10;
+    static constexpr int16_t Port = 6;
+  };
+
+  class SubLED {
+  public:
+    typedef uint8_t pin_t;
+
+  public:
+    static constexpr pin_t Pin = 13;
+  };
+
+  class Thermometer {
+
+  };
+
+  class TouchSensor {
+  public:
+    typedef uint8_t touch_sensor_port_t;
+    typedef uint8_t touch_sensor_index_t;
+
+  public:
+    // 配置場所 -> インデックス
+    class Placement
+    {
+    public:
+      static constexpr touch_sensor_index_t Hair   = 0; // タッチセンサ1 : 髪
+      static constexpr touch_sensor_index_t Chest  = 1; // タッチセンサ2 : 胸
+      static constexpr touch_sensor_index_t Skirt  = 2; // タッチセンサ3 : スカート
+      static constexpr touch_sensor_index_t Ribbon = 3; // タッチセンサ4 : リボン
+    };
+
+    // インデックス -> 接続先ポート
+    class Port
+    {
+    public:
+      static constexpr touch_sensor_port_t Hair   = A1; // タッチセンサ1 : 髪
+      static constexpr touch_sensor_port_t Chest  = A0; // タッチセンサ2 : 胸
+      static constexpr touch_sensor_port_t Skirt  = A2; // タッチセンサ3 : スカート
+      static constexpr touch_sensor_port_t Ribbon = A3; // タッチセンサ4 : リボン
+
+    public:
+      static constexpr touch_sensor_port_t Get(touch_sensor_index_t idx) {
+        return idx == 0 ? Hair : (idx == 1 ? Chest : (idx == 2 ? Skirt : 0));
+      }
+    };
+
+  public:
+    static constexpr touch_sensor_index_t Length = 4;
+  };
+};
+
+#endif

--- a/src/Params/Tenshi.h
+++ b/src/Params/Tenshi.h
@@ -1,0 +1,91 @@
+/*!
+ * Params/Tenshi.h - Library for Moe-PCB (Moe Kiban)
+ *
+ * Copyright (c) 2022-2023 Mizuhasi Yukkie, Onozawa Hiro
+ * Released under the MIT license.
+ * see https://opensource.org/licenses/MIT
+ */
+
+#ifndef Params_Tenshi_h
+#define Params_Tenshi_h
+
+#include <stdint.h>
+#include <Arduino.h>
+
+// 天子の萌基板パラメータ
+class MoePCB_Params_Tenshi
+{
+public:
+  class LED {
+  public:
+    typedef uint8_t led_index_t;
+
+  public:
+    class Placement
+    {
+    public:
+      static constexpr led_index_t Heart       = 0; // LED1 : 胸 (背面)
+      static constexpr led_index_t OuterLeft   = 1; // LED2 : 最左
+      static constexpr led_index_t Left        = 2; // LED3 : 中左
+      static constexpr led_index_t Center      = 3; // LED4 : 中
+      static constexpr led_index_t Right       = 4; // LED5 : 中右
+      static constexpr led_index_t OuterRight  = 5; // LED6 : 最右
+      static constexpr led_index_t SwordBottom = 6; // LED7 : 剣の最下
+
+      static constexpr led_index_t SwordLEDNum = 10; // 剣に配置されたLED個数
+    };
+
+  public:
+    static constexpr led_index_t Length = 16;
+    static constexpr int16_t Port = 6;
+  };
+
+  class SubLED {
+  public:
+    typedef uint8_t pin_t;
+
+  public:
+    static constexpr pin_t Pin = 13;
+  };
+
+  class Thermometer {
+
+  };
+
+  class TouchSensor {
+  public:
+    typedef uint8_t touch_sensor_port_t;
+    typedef uint8_t touch_sensor_index_t;
+
+  public:
+    // 配置場所 -> インデックス
+    class Placement
+    {
+    public:
+      static constexpr touch_sensor_index_t Hair  = 0; // タッチセンサ1 : 髪
+      static constexpr touch_sensor_index_t Chest = 1; // タッチセンサ2 : 胸
+      static constexpr touch_sensor_index_t Skirt = 2; // タッチセンサ3 : スカート
+      static constexpr touch_sensor_index_t Sword = 3; // タッチセンサ4 : 剣
+    };
+
+    // インデックス -> 接続先ポート
+    class Port
+    {
+    public:
+      static constexpr touch_sensor_port_t Hair  = A1; // タッチセンサ1 : 髪
+      static constexpr touch_sensor_port_t Chest = A0; // タッチセンサ2 : 胸
+      static constexpr touch_sensor_port_t Skirt = A2; // タッチセンサ3 : スカート
+      static constexpr touch_sensor_port_t Sword = A3; // タッチセンサ4 : 剣
+
+    public:
+      static constexpr touch_sensor_port_t Get(touch_sensor_index_t idx) {
+        return idx == 0 ? Hair : (idx == 1 ? Chest : (idx == 2 ? Skirt : 0));
+      }
+    };
+
+  public:
+    static constexpr touch_sensor_index_t Length = 3;
+  };
+};
+
+#endif

--- a/src/Params/Tenshi.h
+++ b/src/Params/Tenshi.h
@@ -25,9 +25,9 @@ public:
     {
     public:
       static constexpr led_index_t Heart       = 0; // LED1 : 胸 (背面)
-      static constexpr led_index_t OuterLeft   = 1; // LED2 : 最左
+      static constexpr led_index_t OuterLeft   = 3; // LED2 : 最左
       static constexpr led_index_t Left        = 2; // LED3 : 中左
-      static constexpr led_index_t Center      = 3; // LED4 : 中
+      static constexpr led_index_t Center      = 1; // LED4 : 中
       static constexpr led_index_t Right       = 4; // LED5 : 中右
       static constexpr led_index_t OuterRight  = 5; // LED6 : 最右
       static constexpr led_index_t SwordBottom = 6; // LED7 : 剣の最下
@@ -72,19 +72,19 @@ public:
     class Port
     {
     public:
-      static constexpr touch_sensor_port_t Hair  = A1; // タッチセンサ1 : 髪
-      static constexpr touch_sensor_port_t Chest = A0; // タッチセンサ2 : 胸
-      static constexpr touch_sensor_port_t Skirt = A2; // タッチセンサ3 : スカート
-      static constexpr touch_sensor_port_t Sword = A3; // タッチセンサ4 : 剣
+      static constexpr touch_sensor_port_t Hair  = A0; // タッチセンサ1 : 髪
+      static constexpr touch_sensor_port_t Chest = A1; // タッチセンサ2 : 胸
+      static constexpr touch_sensor_port_t Skirt = A3; // タッチセンサ3 : スカート
+      static constexpr touch_sensor_port_t Sword = A2; // タッチセンサ4 : 剣
 
     public:
       static constexpr touch_sensor_port_t Get(touch_sensor_index_t idx) {
-        return idx == 0 ? Hair : (idx == 1 ? Chest : (idx == 2 ? Skirt : 0));
+        return idx == 0 ? Hair : (idx == 1 ? Chest : (idx == 2 ? Skirt : (idx == 3 ? Sword : 0)));
       }
     };
 
   public:
-    static constexpr touch_sensor_index_t Length = 3;
+    static constexpr touch_sensor_index_t Length = 4;
   };
 };
 


### PR DESCRIPTION
MoePCB クラスをテンプレートクラスにし、必要な機能を必要な分だけもったクラスとして利用できるよう改良します。
このPRを取り込んでいただくと、以下の効果が得られます。
* メモリ消費量を抑えながら、従来とほぼ同様の振る舞いをするプログラムが得られる
* 従来のサンプルも引き続き利用できる
* 機能をモジュールという単位で分割したため、ハードウェアに新たな機能が搭載された場合に容易に拡張できる


実装作業中のためまだしばらくは取り込まないでいただきたいのですが、作業状況の共有の意味でPRを作成しました。

現時点でチルノ (KNMK-0002A_Cirduino_Basic.ino) については、
新規実装した萌基板クラスを利用したサンプルを作成してあります (KNMK-0002A_Cirduino_Basic_New.ino) 。
比較的高い精度で元実装と同じ振る舞いをしつつ、
メモリ消費量をかなり削減することができています (Flash: 12342 -> 10150 byte, RAM: 1108 -> 388 byte) 。

このPRを取り込んでいただけるよう、以下の実装作業を進めていきます。

- [ ] フラン、雛、天子の実装の再現度向上とサンプル追加
- [ ] 雛、天子用の環境センサモジュール実装
- [ ] コードフォーマット、コーディングルールの統一

また、後継のパチュリー、魔理沙、紫のプログラムをpushしていただけた場合は、以下の実装も行う予定です。
- [ ] 赤外線LED、センサのモジュール実装
- [ ] パチュリー、魔理沙、紫の再現実装サンプル追加
- [ ] 改良版フラン、チルノ実装への追従 (?)
  - 再生産版 (2023春例版) のチルノと初期版チルノの動作が違うようなので、改良されているものと思っております。
